### PR TITLE
Mimic $.ajax behavior, improve robustness

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -71,7 +71,11 @@ function add(s, k, v) {
  */
 export function headersToObject(headers) {
   let headersObject = {};
-  headers.forEach((value, key) => headersObject[key] = value);
+
+  if (headers) {
+    headers.forEach((value, key) => headersObject[key] = value);
+  }
+
   return headersObject;
 }
 /**
@@ -90,12 +94,16 @@ export function mungOptionsForFetch(_options, adapter) {
     // This double use of `combineObjs` is necessary because `merge` only accepts two arguments.
     options.headers = combineObjs(combineObjs({}, options.headers || {}), adapterHeaders);
   }
-  options.method = options.type;
+
+  // Default to 'GET' in case `type` is not passed in (mimics jQuery.ajax).
+  options.method = options.type || 'GET';
 
   // GET and HEAD requests can't have a `body`
   if (options.data && Object.keys(options.data).length) {
     if (options.method === 'GET' || options.method === 'HEAD') {
-      options.url += `?${serialiazeQueryParams(options.data)}`;
+      // Test if there are already query params in the url (mimics jQuey.ajax).
+      const queryParamDelimiter = options.url.indexOf('?') > -1 ? '&' : '?';
+      options.url += `${queryParamDelimiter}${serialiazeQueryParams(options.data)}`;
     } else {
       options.body = options.data;
     }
@@ -211,7 +219,7 @@ export default Ember.Mixin.create({
    * @param {Object} requestData
    * @override
    */
-  ajaxError(error, response, requestData) {
+  ajaxError(error, response = {}, requestData) {
     if (error instanceof Error) {
       return error;
     } else {

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -179,6 +179,38 @@ test('mungOptionsForFetch takes the headers from the adapter if present', functi
   }, 'POST call\'s options are correct');
 });
 
+test('mungOptionsForFetch sets the method to "GET" if `type` is not provided', function(assert) {
+  assert.expect(1);
+  const getOptions = {
+    url: 'https://emberjs.com',
+    type: undefined,
+  };
+
+  const options = mungOptionsForFetch(getOptions, this.basicAdapter);
+  assert.equal(options.method, 'GET');
+});
+
+test('mungOptionsForFetch adds string query params to the url correctly', function(assert) {
+  assert.expect(2);
+
+  const baseUrl = 'https://emberjs.com';
+  const noQueryStringOptions = {
+    url: baseUrl,
+    data: { a: 1, b: 2 }
+  };
+
+  let options = mungOptionsForFetch(noQueryStringOptions, this.basicAdapter);
+  assert.equal(options.url, `${baseUrl}?a=1&b=2`, 'url that started without query params has query params');
+
+  const hasQueryStringOptions = {
+    url: `${baseUrl}?fastboot=true`,
+    data: { a: 1, b: 2 }
+  };
+
+  options = mungOptionsForFetch(hasQueryStringOptions, this.basicAdapter);
+  assert.equal(options.url, `${baseUrl}?fastboot=true&a=1&b=2`, 'url that started with query params has more query params');
+});
+
 test('headersToObject turns an Headers instance into an object', function (assert) {
   assert.expect(1);
 
@@ -187,6 +219,13 @@ test('headersToObject turns an Headers instance into an object', function (asser
   const headerObject = headersToObject(headers);
 
   assert.deepEqual(headerObject, exampleHeaders);
+});
+
+test('headersToObject returns an empty object if no headers are passed to it', function (assert) {
+  assert.expect(1);
+
+  const headerObject = headersToObject();
+  assert.deepEqual(headerObject, {});
 });
 
 test('serialiazeQueryParams turns deeply nested objects into queryParams like $.param', function (assert) {


### PR DESCRIPTION
jQuery.ajax behaviors to mimic:
* Default to method `GET` if one is not provided.
* If the `url` in options already has query params, handle this when we process `options.data` to add additional query params.

Increase robustness:
* `headersToObject` should not error if no headers come back from the server.
* `ajaxError` should have a default  empty object for its `response` arg in the case where the fetch request throws an error and there is no response. 