### PR TITLE
Stringify data for a POST request

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -106,20 +106,28 @@ export function mungOptionsForFetch(_options, adapter) {
   options.method = options.type || 'GET';
 
   // GET and HEAD requests can't have a `body`
-  if (options.data && Object.keys(options.data).length) {
+  if (options.data) {
     if (options.method === 'GET' || options.method === 'HEAD') {
       // Test if there are already query params in the url (mimics jQuey.ajax).
       const queryParamDelimiter = options.url.indexOf('?') > -1 ? '&' : '?';
       options.url += `${queryParamDelimiter}${serialiazeQueryParams(options.data)}`;
     } else {
-      // Strip out keys with undefined or null values (mimics jQuery.ajax).
-      options.body = Object.keys(options.data).reduce((filteredObj, key) => {
-        const currentValue = options.data[key];
-        if (currentValue != undefined) {
-          filteredObj[key] = currentValue;
-        }
-        return filteredObj;
-      }, {});
+      // NOTE: a request's body cannot be an object, so we stringify it if it is.
+      if (typeof options.data === 'string') {
+        // JSON.stringify removes keys with values of `undefined`.
+        options.body = options.data;
+      } else {
+        // Strip out keys with undefined or null values (mimics jQuery.ajax).
+        const filteredBody = Object.keys(options.data).reduce((filteredObj, key) => {
+          const currentValue = options.data[key];
+          if (currentValue != undefined) {
+            filteredObj[key] = currentValue;
+          }
+          return filteredObj;
+        }, {});
+
+        options.body = JSON.stringify(filteredBody);
+      }
     }
   }
 

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -75,9 +75,7 @@ test('mungOptionsForFetch transforms jQuery-style options into fetch compatible 
       'custom-header' : 'foo',
       'Content-Type': 'application/json; charset=utf-8'
     },
-    body: {
-      a: 1
-    },
+    body: "{\"a\":1}",
     data: {
       a: 1
     },
@@ -211,24 +209,41 @@ test('mungOptionsForFetch adds string query params to the url correctly', functi
   assert.equal(options.url, `${baseUrl}?fastboot=true&a=1&b=2`, 'url that started with query params has more query params');
 });
 
-test('mungOptionsForFetch removes undefined and null query params when method is POST', function(assert) {
+test('mungOptionsForFetch removes undefined and null query params when method is POST and \'data\' is an object', function(assert) {
   assert.expect(1);
 
-  const undefinedQueryStringOptions = {
-    url: 'https://emberjs.com',
-    type: 'POST',
-    data: {
+  const dataAsObject = {
       a: 1,
       b: undefined,
       c: 3,
       d: null,
       e: 0,
       f: false
-    }
+    };
+
+  const undefinedQueryStringOptions = {
+    url: 'https://emberjs.com',
+    type: 'POST',
+    data: dataAsObject
   };
 
   let options = mungOptionsForFetch(undefinedQueryStringOptions, this.basicAdapter);
-  assert.deepEqual(options.body, { a: 1, c: 3, e: 0, f: false });
+  assert.deepEqual(options.body, "{\"a\":1,\"c\":3,\"e\":0,\"f\":false}");
+});
+
+test('mungOptionsForFetch sets the request body correctly when the method is POST and \'data\' is a string', function(assert) {
+  assert.expect(1);
+
+  const stringifiedData = JSON.stringify({a:1, b:2});
+
+  const dataAsString = {
+    url: 'https://emberjs.com',
+    type: 'POST',
+    data: stringifiedData,
+  };
+
+  let options = mungOptionsForFetch(dataAsString, this.basicAdapter);
+  assert.deepEqual(options.body, stringifiedData);
 });
 
 test('headersToObject turns an Headers instance into an object', function (assert) {


### PR DESCRIPTION
Fetch expects the body of a POST request to be one of several special objects

```
Note: The body type can only be a Blob, BufferSource, FormData, URLSearchParams, USVString
or ReadableStream type, so for adding a JSON object to the payload you need to stringify
that object.
```

Have `mungOptionsForFetch` take care of this for us.