### PR TITLE
Fix and test support for URLSearchParams bodies

### DIFF
--- a/assets/browser-fetch.js.t
+++ b/assets/browser-fetch.js.t
@@ -11,6 +11,9 @@
     if (global.Blob) {
       self.Blob = global.Blob;
     }
+    if (global.URLSearchParams) {
+      self.URLSearchParams = global.URLSearchParams;
+    }
 
     <%= moduleBody %>
 

--- a/tests/acceptance/root-test.js
+++ b/tests/acceptance/root-test.js
@@ -79,6 +79,30 @@ test('posting a form', function(assert) {
     assert.equal(data.name, 'World');
   });
 });
+test('posting a search params form', function(assert) {
+  server.post('/upload', function(req) {
+    assert.equal(req.requestHeaders['content-type'], 'application/x-www-form-urlencoded;charset=UTF-8');
+
+    return [
+      200,
+      { 'Content-Type': 'text/json'},
+      JSON.stringify({ name: 'World' })
+    ];
+  });
+
+  var form = new window.URLSearchParams();
+  form.append('foo', 'bar');
+
+  return fetch('/upload', {
+    method: 'post',
+    body: form
+  }).then(function (res) {
+    assert.equal(res.status, 200);
+    return res.json();
+  }).then(function (data) {
+    assert.equal(data.name, 'World');
+  });
+});
 
 test('tests await for fetch requests', function(assert) {
   server.get('/omg.json', function() {


### PR DESCRIPTION
github/fetch supports this, but it seems that the URLSearchParams global needs to be passed into the module.

I've added a test, but even with this fix it fails due to Phantom's lack of support for URLSearchParams. Not sure what you want to do here.