### PR TITLE
Upgrade node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "broccoli-stew": "^1.4.2",
     "broccoli-templater": "^1.0.0",
     "ember-cli-babel": "^6.0.0",
-    "node-fetch": "^2.0.0-alpha.3",
+    "node-fetch": "^2.0.0-alpha.6",
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3875,11 +3875,9 @@ node-fetch@^1.3.3:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.0.0-alpha.3:
-  version "2.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0-alpha.4.tgz#ae3fe092fef710a7e565e68d5fcccefabad674b6"
-  dependencies:
-    encoding "^0.1.11"
+node-fetch@^2.0.0-alpha.6:
+  version "2.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0-alpha.6.tgz#2fafa63b4a248f8d6b67a239fc16299a35641161"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Node-fetch released a patch release which fixes a bug where the module `encoding` was removed as a dependency. This seems to be causing issues in fastboot deployments where`encoding` is missing. This fixes the issue.