### PR TITLE
fix: add method to allow for overwriting the payload of an error response.

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -235,6 +235,17 @@ export default Ember.Mixin.create({
     });
   },
 
+
+/**
+ * Allows for the error to be parsed out of the response.
+ * Fetch returns the body of an error response in a `_bodyText`
+ * property that one might wish to extract instead of the statusText.
+ * @param {Object} response
+ */
+  parseFetchResponseForError(response) {
+    return response.statusText;
+  },
+
   /**
    * @param {Error} error
    * @param {Object} response
@@ -248,7 +259,7 @@ export default Ember.Mixin.create({
        return this.handleResponse(
         response.status,
          headersToObject(response.headers),
-        this.parseErrorResponse(response.statusText) || error,
+        this.parseErrorResponse(this.parseFetchResponseForError(response)) || error,
         requestData
       );
     }

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -348,6 +348,28 @@ test('determineBodyResponse returns an empty object when the request method is \
   });
 });
 
+test('parseFetchResponseForError is able to be overwritten to mutate the error payload that gets passed along', function(assert) {
+  assert.expect(1);
+
+  this.errorAdapter = JSONAPIAdapter.extend(AdapterFetchMixin, {
+    _fetchRequest() {
+      const response = new Response(`{ "errors": ["myoneerror"] }`, {status: 422});
+      return Ember.RSVP.Promise.resolve(response);
+    },
+    parseFetchResponseForError() {
+      return {
+        errors: ['myOverWrittenError']
+      }
+    }
+  }).create();
+
+  const fetchReturn = this.errorAdapter.ajax({url: '/foo'});
+
+  return fetchReturn.catch((body) => {
+    assert.deepEqual(body.errors, ["myOverWrittenError"]);
+  });
+});
+
 test('default fetch hook is correctly called if not overriden', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
In relation to my earlier bug, #58, this allows a given adapter to overwrite the payload that gets passed back when a network error is encountered.