### PR TITLE
Brought the ajaxError and ajaxSuccess methods more inline with standard ember data methods

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -183,15 +183,15 @@ export default Ember.Mixin.create({
       })
       .then((response) => {
         return RSVP.hash({
-          responseData: determineBodyPromise(response, requestData),
-          response
+          response,
+          payload: determineBodyPromise(response, requestData)
         });
       })
-      .then(({response, responseData}) => {
+      .then(({ response, payload }) => {
         if (response.ok) {
-          return this.ajaxSuccess(this, response, responseData, requestData);
+          return this.ajaxSuccess(this, response, payload, requestData);
         } else {
-          throw this.ajaxError(this, response, requestData, responseData);
+          throw this.ajaxError(this, response, requestData, payload);
         }
       });
   },
@@ -260,11 +260,11 @@ export default Ember.Mixin.create({
     if (responseData instanceof Error) {
       return responseData;
     } else {
-      const parsedResponse = this.parseFetchResponseForError(response, responseData);
-      return this.handleResponse(
+      const parsedResponse = adapter.parseFetchResponseForError(response, responseData);
+      return adapter.handleResponse(
         response.status,
         headersToObject(response.headers),
-        this.parseErrorResponse(parsedResponse) || responseData,
+        adapter.parseErrorResponse(parsedResponse) || responseData,
         requestData
       );
     }

--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -155,6 +155,9 @@ export function determineBodyPromise(response, requestData) {
     try {
       payload = JSON.parse(payload);
     } catch(error) {
+      if (!(error instanceof SyntaxError)) {
+        throw error;
+      }
       const status = response.status;
       if (response.ok && (status === 204 || status === 205 || requestData.method === 'HEAD')) {
         payload = { data: null };

--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -143,9 +143,11 @@ export function mungOptionsForFetch(_options, adapter) {
 }
 /**
  * Function that always attempts to parse the response as json, and if an error is thrown,
- * returns an object with 'data' set to null if the response is a sucess, and
- * the plain payload if the response was an error.
+ * returns an object with 'data' set to null if the response is
+ * a sucess and has a status code of 204 (No Content) or 205 (Reset Content) or if the request method was 'HEAD',
+ * and the plain payload otherwise.
  * @param {Response} response
+ * @param {Object} requestData
  * @returns {Promise}
  */
 export function determineBodyPromise(response, requestData) {

--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -183,7 +183,7 @@ export default Ember.Mixin.create({
 
     return this._ajaxRequest(hash)
       .catch((error, response, requestData) => {
-        throw this.ajaxError(this, response, requestData, error);
+        throw this.ajaxError(this, response, null, requestData, error);
       })
       .then((response) => {
         return RSVP.hash({
@@ -195,7 +195,7 @@ export default Ember.Mixin.create({
         if (response.ok) {
           return this.ajaxSuccess(this, response, payload, requestData);
         } else {
-          throw this.ajaxError(this, response, requestData, payload);
+          throw this.ajaxError(this, response, payload, requestData);
         }
       });
   },
@@ -247,28 +247,29 @@ export default Ember.Mixin.create({
  * Allows for the error to be selected from either the
  * response object, or the response data.
  * @param {Object} response
- * @param {Object} responseData
+ * @param {Object} payload
  */
-  parseFetchResponseForError(response, responseData) {
-    return responseData;
+  parseFetchResponseForError(response, payload) {
+    return payload || response.statusTest;
   },
 
   /**
    * @param {Object} adapter
    * @param {Object} response
+   * @param {String|Object} payload
    * @param {Object} requestData
-   * @param {Object} responseData
+   * @param {Error} error
    * @override
    */
-  ajaxError(adapter, response, requestData, responseData) {
-    if (responseData instanceof Error) {
-      return responseData;
+  ajaxError(adapter, response, payload, requestData, error) {
+    if (error) {
+      return error;
     } else {
-      const parsedResponse = adapter.parseFetchResponseForError(response, responseData);
+      const parsedResponse = adapter.parseFetchResponseForError(response, payload);
       return adapter.handleResponse(
         response.status,
         headersToObject(response.headers),
-        adapter.parseErrorResponse(parsedResponse) || responseData,
+        adapter.parseErrorResponse(parsedResponse) || payload,
         requestData
       );
     }

--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -4,7 +4,8 @@ import fetch from 'fetch';
 const {
   assign,
   merge,
-  RSVP
+  RSVP,
+  Logger: { warn }
 } = Ember;
 
 const RBRACKET = /\[\]$/;
@@ -147,12 +148,17 @@ export function mungOptionsForFetch(_options, adapter) {
  * @param {Response} response
  * @returns {Promise}
  */
-export function determineBodyPromise(response) {
+export function determineBodyPromise(response, requestData) {
   return response.text().then(function(payload) {
     try {
       payload = JSON.parse(payload);
     } catch(error) {
-      payload = response.ok ? { data: null } : payload;
+      const status = response.status;
+      if (response.ok && (status === 204 || status === 205 || requestData.method === 'HEAD')) {
+        payload = { data: null };
+      } else {
+        warn('This response was unable to be parsed as json.', payload);
+      }
     }
     return payload;
   });

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -348,6 +348,28 @@ test('determineBodyResponse returns an empty object when the request method is \
   });
 });
 
+test('parseFetchResponseForError is able to be overwritten to mutate the error payload that gets passed along', function(assert) {
+  assert.expect(1);
+
+  this.errorAdapter = JSONAPIAdapter.extend(AdapterFetchMixin, {
+    _fetchRequest() {
+      const response = new Response(`{ "errors": ["myoneerror"] }`, {status: 422});
+      return Ember.RSVP.Promise.resolve(response);
+    },
+    parseFetchResponseForError() {
+      return {
+        errors: ['myOverWrittenError']
+      }
+    }
+  }).create();
+
+  const fetchReturn = this.errorAdapter.ajax({url: '/foo'});
+
+  return fetchReturn.catch((body) => {
+    assert.deepEqual(body.errors, ["myOverWrittenError"]);
+  });
+});
+
 test('default fetch hook is correctly called if not overriden', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -374,7 +374,7 @@ test('parseFetchResponseForError is able to be overwritten to mutate the error p
     }
   }).create();
 
-  const fetchReturn = this.errorAdapter.ajax({url: '/trigger-a-server-error-with-content'});
+  const fetchReturn = this.errorAdapter.ajax('/trigger-a-server-error-with-content');
 
   return fetchReturn.catch((body) => {
     assert.deepEqual(body.errors, ["myOverWrittenError"]);
@@ -391,7 +391,7 @@ test('able to handle empty error payloads', function(assert) {
     }
   }).create();
 
-  const fetchReturn = this.errorAdapter.ajax({url: '/trigger-an-empty-server-error'});
+  const fetchReturn = this.errorAdapter.ajax('/trigger-an-empty-server-error');
 
   return fetchReturn.catch((body) => {
     const error = body.errors[0]

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -374,7 +374,7 @@ test('parseFetchResponseForError is able to be overwritten to mutate the error p
     }
   }).create();
 
-  const fetchReturn = this.errorAdapter.ajax({url: '/foo'});
+  const fetchReturn = this.errorAdapter.ajax({url: '/trigger-a-server-error-with-content'});
 
   return fetchReturn.catch((body) => {
     assert.deepEqual(body.errors, ["myOverWrittenError"]);
@@ -391,7 +391,7 @@ test('able to handle empty error payloads', function(assert) {
     }
   }).create();
 
-  const fetchReturn = this.errorAdapter.ajax({url: '/foo'});
+  const fetchReturn = this.errorAdapter.ajax({url: '/trigger-an-empty-server-error'});
 
   return fetchReturn.catch((body) => {
     const error = body.errors[0]

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -370,6 +370,25 @@ test('parseFetchResponseForError is able to be overwritten to mutate the error p
   });
 });
 
+test('able to handle empty error payloads', function(assert) {
+  assert.expect(2);
+
+  this.errorAdapter = JSONAPIAdapter.extend(AdapterFetchMixin, {
+    _fetchRequest() {
+      const response = new Response(``, {status: 500});
+      return Ember.RSVP.Promise.resolve(response);
+    }
+  }).create();
+
+  const fetchReturn = this.errorAdapter.ajax({url: '/foo'});
+
+  return fetchReturn.catch((body) => {
+    const error = body.errors[0]
+    assert.equal(error.detail, '');
+    assert.equal(error.status, '500');
+  });
+});
+
 test('default fetch hook is correctly called if not overriden', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -315,6 +315,17 @@ test('determineBodyResponse returns the body when it is present', function(asser
   });
 });
 
+test('determineBodyResponse returns the body even if it is not json', function(assert) {
+  assert.expect(1);
+
+  const response = new Response('this is not json', {status: 200});
+  const bodyPromise = determineBodyPromise(response, {});
+
+  return bodyPromise.then((body) => {
+    assert.deepEqual(body, 'this is not json');
+  });
+});
+
 test('determineBodyResponse returns an empty object when the http status code is 204', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
In ember data, both the ajaxError and ajaxSuccess methods receive the payload that was returned from the server. Bringing this adapter more inline with how those function.

Would be nice to be able to, in the future, rework these so that we can just call the super method and return those instead of rewriting all the logic ourselves in these methods.

Going to close #59 in favor of this solution.