### PR TITLE
Drop runtime Ember module usage

### DIFF
--- a/assets/browser-fetch.js.t
+++ b/assets/browser-fetch.js.t
@@ -1,7 +1,7 @@
 (function (global) {
-  define('fetch', ['ember', 'exports'], function(Ember, self) {
+  define('fetch', ['exports'], function(self) {
     'use strict';
-    var Promise = Ember['default'].RSVP.Promise;
+    var Promise = global.Ember.RSVP.Promise;
     if (global.FormData) {
       self.FormData = global.FormData;
     }
@@ -20,8 +20,8 @@
       return result;
     }
 
-    if (Ember.default.Test) {
-      Ember.default.Test.registerWaiter(function() {
+    if (global.Ember.Test) {
+      global.Ember.Test.registerWaiter(function() {
         return pending === 0;
       });
 


### PR DESCRIPTION
To permit this library to be used when there is no ember-cli-shims addon in the host app, drop the modules usage in `browser-fetch.js`. Instead, reach for the global `Ember` object directly.