### PR TITLE
[fastboot-fix]: Only define 'fetch' when FastBoot is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-fetch",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "HTML5 Fetch polyfill (as an ember-addon)",
   "typings": "./index.d.ts",
   "keywords": [

--- a/public/fastboot-fetch.js
+++ b/public/fastboot-fetch.js
@@ -1,4 +1,8 @@
 (function() {
+  if (typeof FastBoot === 'undefined' || typeof FastBoot.require === 'undefined') {
+    return
+  }
+
   define('fetch', ['exports'], function(self) {
     var fetch = FastBoot.require('node-fetch');
     self['default'] = fetch;


### PR DESCRIPTION
This PR is a fork to fix Issue https://github.com/ember-cli/ember-fetch/issues/69

Don't want this file `fastboot-fetch.js` to go to browser, when not using FastBoot.