### PR TITLE
Override Ember Data's ajaxOptions

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -165,6 +165,20 @@ export function determineBodyPromise(response, requestData) {
 }
 
 export default Ember.Mixin.create({
+/**
+ * @param {String} url
+ * @param {String} type
+ * @param {Object} _options
+ * @returns {Object}
+ * @override
+ */
+
+  ajaxOptions(url, type, options = {}) {
+    options.url = url;
+    options.type = type;
+    return mungOptionsForFetch(options, this);
+  },
+
   /**
    * @param {String} url
    * @param {String} type
@@ -203,8 +217,7 @@ export default Ember.Mixin.create({
    * @param {Object} options
    * @override
    */
-  _ajaxRequest(_options) {
-    const options = mungOptionsForFetch(_options, this);
+  _ajaxRequest(options) {
     return this._fetchRequest(options.url, options);
   },
 

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -437,3 +437,30 @@ test('overridden fetch hook is called when supplied', function(assert) {
   const fetchReturn = this.JSONAPIAdapter._ajaxRequest({});
   assert.equal(fetchReturn, newText);
 });
+
+test('ajaxOptions returns the correct data', function(assert) {
+  assert.expect(1);
+
+  const ajaxOptionsReturn = this.JSONAPIAdapter.ajaxOptions('/url', 'GET', {
+    data: {
+      a: 1
+    },
+    headers: {
+      'secret-key': 1234
+    }
+  });
+
+  assert.deepEqual(ajaxOptionsReturn, {
+    url: '/url?a=1',
+    method: 'GET',
+    type: 'GET',
+    credentials: 'same-origin',
+    data: {
+      "a": 1
+    },
+    headers: {
+      'custom-header': 'foo',
+      'secret-key': 1234
+    },
+  });
+});


### PR DESCRIPTION
There is no reason to call DS.RESTAdapter's `ajaxOptions` as most of the work is jQuery specific and not needed. Additionally, moving `mungOptionsForFetch` to `ajaxOptions` instead of `_ajaxRequest` better mimics ED's patterns.

This PR:
* Overrides `DS.RESTAdapter#ajaxOptions`
* Adds test for this mixin's `ajaxOptions`