### PR TITLE
Convert request body to JSON if it is a string

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -116,14 +116,9 @@ export function mungOptionsForFetch(_options, adapter) {
       const queryParamDelimiter = options.url.indexOf('?') > -1 ? '&' : '?';
       options.url += `${queryParamDelimiter}${serialiazeQueryParams(options.data)}`;
     } else {
-      // NOTE: a request's body cannot be an object, so we stringify it if it is.
-      if (typeof options.data === 'string') {
-        // JSON.stringify has already removed keys with values of `undefined`.
-        options.body = options.data;
-      } else {
-        // JSON.stringify removes keys with values of `undefined` (mimics jQuery.ajax).
-        options.body = JSON.stringify(options.data);
-      }
+      // NOTE: a request's body must be JSON.
+      // If `data` is an object, JSON.stringify removes keys with values of `undefined` (mimics jQuery.ajax).
+      options.body = JSON.stringify(options.data);
     }
   }
 

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -177,6 +177,19 @@ test('mungOptionsForFetch takes the headers from the adapter if present', functi
   }, 'POST call\'s options are correct');
 });
 
+test('mungOptionsForFetch creates a valid JSON POST body when `data` is a string', function(assert) {
+  assert.expect(1);
+  const data = 'foo';
+  const optionsWithStringData = {
+    url: 'https://emberjs.com',
+    type: 'POST',
+    data
+  };
+
+  let options = mungOptionsForFetch(optionsWithStringData, this.JSONAPIAdapter);
+  assert.equal(options.body, JSON.stringify(data));
+});
+
 test('mungOptionsForFetch sets the method to "GET" if `type` is not provided', function(assert) {
   assert.expect(1);
   const getOptions = {


### PR DESCRIPTION
Hi, close this PR if it is not intended behavior.

In version 3.3.1, ember-fetch would convert string POST data to JSON, which is a behavior that we relied on.

Now in version 3.4.0, ember-fetch just leaves strings as is. So `foo` remains as `foo` when sent to the server. But, in 3.3.1 ember-fetch would convert `foo` to `"foo"`, a valid JSON serialized string, which is what the backend expects. I wrote a unit test to highlight this behavior.

I noticed that there's another unit test which seems to indicate that 3.4.0 breaks the old behavior intentionally, therefore I'll have to stringify all data before making the ajax call. I wonder about the design decision behind this, as it's strange how JSON.stringify gets called for objects, but not strings. I don't think this new design is bad, though, but I wish that the CHANGELOG made it clearer.