### PR TITLE
add FormData support to fastboot

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "broccoli-stew": "^1.4.2",
     "broccoli-templater": "^1.0.0",
     "ember-cli-babel": "^6.8.1",
+    "form-data": "^2.3.1",
     "node-fetch": "^2.0.0-alpha.9",
     "whatwg-fetch": "^2.0.3"
   },
@@ -50,7 +51,8 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "fastbootDependencies": [
-      "node-fetch"
+      "node-fetch",
+      "form-data"
     ]
   }
 }

--- a/public/fastboot-fetch.js
+++ b/public/fastboot-fetch.js
@@ -5,6 +5,7 @@
     self['Headers'] = fetch.Headers;
     self['Request'] = fetch.Request;
     self['Response'] = fetch.Response;
+    self['FormData'] = FastBoot.require('form-data');
   });
 
   define('fetch/ajax', ['exports'], function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,6 +2738,14 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
+form-data@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
+
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"


### PR DESCRIPTION
We do expose `FormData` in the browser so it make sens to me to expose it also in fastboot.