### PR TITLE
remove app re-export of mixin

### DIFF
--- a/app/mixins/adapter-fetch.js
+++ b/app/mixins/adapter-fetch.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-fetch/mixins/adapter-fetch';


### PR DESCRIPTION
I think this was added by mistake, and since the readme doesn't make use of it, I don't think it is a breaking change to remove it.