### PR TITLE
Fix non GET/HEAD requests having no body set

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -108,12 +108,14 @@ export function mungOptionsForFetch(_options, adapter) {
 
   if (options.data) {
     // GET and HEAD requests can't have a `body`
-    // If no options are passed, Ember Data sets `data` to an empty object, which we test for.
-    if ((options.method === 'GET' || options.method === 'HEAD') && Object.keys(options.data).length) {
-      // Test if there are already query params in the url (mimics jQuey.ajax).
-      const queryParamDelimiter = options.url.indexOf('?') > -1 ? '&' : '?';
-      options.url += `${queryParamDelimiter}${serializeQueryParams(options.data)}`;
-    } else if (options.method === 'POST') {
+    if ((options.method === 'GET' || options.method === 'HEAD')) {
+      // If no options are passed, Ember Data sets `data` to an empty object, which we test for.
+      if (Object.keys(options.data).length) {
+        // Test if there are already query params in the url (mimics jQuey.ajax).
+        const queryParamDelimiter = options.url.indexOf('?') > -1 ? '&' : '?';
+        options.url += `${queryParamDelimiter}${serializeQueryParams(options.data)}`;
+      }
+    } else {
       // NOTE: a request's body cannot be an object, so we stringify it if it is.
       // JSON.stringify removes keys with values of `undefined` (mimics jQuery.ajax).
       options.body = JSON.stringify(options.data);

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -231,6 +231,30 @@ test('mungOptionsForFetch removes undefined query params when method is POST and
   assert.deepEqual(options.body, "{\"a\":1,\"c\":3,\"d\":null,\"e\":0,\"f\":false}");
 });
 
+test('mungOptionsForFetch sets the request body correctly when the method is not GET or HEAD', function(assert) {
+  assert.expect(3);
+
+  const baseOptions = {
+    url: '/',
+    type: 'POST',
+    data: { a: 1 }
+  };
+
+  // Tests POST method.
+  let options = mungOptionsForFetch(baseOptions, this.basicAdapter);
+  assert.equal(options.body, JSON.stringify(baseOptions.data), 'POST request body correctly set');
+
+  // Tests PUT method.
+  baseOptions.type = 'PUT';
+  options = mungOptionsForFetch(baseOptions, this.basicAdapter);
+  assert.equal(options.body, JSON.stringify(baseOptions.data), 'PUT request body correctly set');
+
+  // Tests DELETE method.
+  baseOptions.type = 'DELETE';
+  options = mungOptionsForFetch(baseOptions, this.basicAdapter);
+  assert.equal(options.body, JSON.stringify(baseOptions.data), 'DELETE request has the correct body');
+});
+
 test('mungOptionsForFetch sets the request body correctly when the method is POST and \'data\' is a string', function(assert) {
   assert.expect(2);
 
@@ -258,14 +282,14 @@ test('mungOptionsForFetch does not set a request body when the method is GET or 
 
   const baseOptions = {
     url: '/',
-    method: 'GET',
+    type: 'GET',
     data: { a: 1 }
   };
 
   let options = mungOptionsForFetch(baseOptions, this.basicAdapter);
   assert.equal(options.body, undefined, 'GET request does not have a request body');
 
-  baseOptions.method = 'HEAD';
+  baseOptions.type = 'HEAD';
   options = mungOptionsForFetch(baseOptions, this.basicAdapter);
   assert.equal(options.body, undefined, 'HEAD request does not have a request body');
 
@@ -273,7 +297,7 @@ test('mungOptionsForFetch does not set a request body when the method is GET or 
   options = mungOptionsForFetch(baseOptions, this.basicAdapter);
   assert.equal(options.body, undefined, 'HEAD request does not have a request body when `data` is an empty object');
 
-  baseOptions.method = 'GET';
+  baseOptions.type = 'GET';
   options = mungOptionsForFetch(baseOptions, this.basicAdapter);
   assert.equal(options.body, undefined, 'GET request does not have a request body when `data` is an empty object');
 });


### PR DESCRIPTION
Fixes a bug in the last commit that excluded non-POST requests from getting their request body set (fixes #86).

* Fixes issue
* add tests to catch in the future

@rwjblue @jcao219