### PR TITLE
make `ember-fetch/ajax` serialize query params

### DIFF
--- a/addon/ajax.js
+++ b/addon/ajax.js
@@ -1,7 +1,21 @@
 import fetch from 'fetch';
+import serializeQueryParams from './utils/serialize-query-params';
 
-export default function ajax(...args) {
-  return fetch(...args).then(response => {
+export default function ajax(url, options = {}) {
+  if (options.data) {
+    // GET and HEAD requests can't have a `body`
+    if ((!options.method || options.method === 'GET' || options.method === 'HEAD')) {
+      if (Object.keys(options.data).length) {
+        // Test if there are already query params in the url (mimics jQuey.ajax).
+        const queryParamDelimiter = url.indexOf('?') > -1 ? '&' : '?';
+        url += `${queryParamDelimiter}${serializeQueryParams(options.data)}`;
+      }
+    } else {
+      options.body = options.data;
+    }
+  }
+
+  return fetch(url, options).then(response => {
     if (response.ok) {
       return response.json();
     }

--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import fetch from 'fetch';
+import serializeQueryParams from '../utils/serialize-query-params';
 
 const {
   assign,
@@ -7,67 +8,6 @@ const {
   RSVP,
   Logger: { warn }
 } = Ember;
-
-const RBRACKET = /\[\]$/;
-
-/**
- * Helper function that turns the data/body of a request into a query param string.
- * This is directly copied from jQuery.param.
- * @param {Object} queryParamsObject
- * @returns {String}
- */
-export function serializeQueryParams(queryParamsObject) {
-  var s = [];
-
-  function buildParams(prefix, obj) {
-    var i, len, key;
-
-    if (prefix) {
-      if (Array.isArray(obj)) {
-        for (i = 0, len = obj.length; i < len; i++) {
-          if (RBRACKET.test(prefix)) {
-            add(s, prefix, obj[i]);
-          } else {
-            buildParams(prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']', obj[i]);
-          }
-        }
-      } else if (obj && String(obj) === '[object Object]') {
-        for (key in obj) {
-          buildParams(prefix + '[' + key + ']', obj[key]);
-        }
-      } else {
-        add(s, prefix, obj);
-      }
-    } else if (Array.isArray(obj)) {
-      for (i = 0, len = obj.length; i < len; i++) {
-        add(s, obj[i].name, obj[i].value);
-      }
-    } else {
-      for (key in obj) {
-        buildParams(key, obj[key]);
-      }
-    }
-    return s;
-  }
-
-  return buildParams('', queryParamsObject).join('&').replace(/%20/g, '+');
-}
-
-/**
- * Part of the `serializeQueryParams` helper function.
- * @param {Array} s
- * @param {String} k
- * @param {String} v
- */
-function add(s, k, v) {
-  // Strip out keys with undefined or null values (mimics jQuery.ajax).
-  if (v === undefined) {
-    return;
-  }
-
-  v = typeof v === 'function' ? v() : v;
-  s[s.length] = `${encodeURIComponent(k)}=${encodeURIComponent(v)}`;
-}
 
 /**
  * Helper function to create a plain object from the response's Headers.

--- a/addon/utils/serialize-query-params.js
+++ b/addon/utils/serialize-query-params.js
@@ -1,0 +1,60 @@
+const RBRACKET = /\[\]$/;
+
+/**
+ * Helper function that turns the data/body of a request into a query param string.
+ * This is directly copied from jQuery.param.
+ * @param {Object} queryParamsObject
+ * @returns {String}
+ */
+export default function serializeQueryParams(queryParamsObject) {
+  var s = [];
+
+  function buildParams(prefix, obj) {
+    var i, len, key;
+
+    if (prefix) {
+      if (Array.isArray(obj)) {
+        for (i = 0, len = obj.length; i < len; i++) {
+          if (RBRACKET.test(prefix)) {
+            add(s, prefix, obj[i]);
+          } else {
+            buildParams(prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']', obj[i]);
+          }
+        }
+      } else if (obj && String(obj) === '[object Object]') {
+        for (key in obj) {
+          buildParams(prefix + '[' + key + ']', obj[key]);
+        }
+      } else {
+        add(s, prefix, obj);
+      }
+    } else if (Array.isArray(obj)) {
+      for (i = 0, len = obj.length; i < len; i++) {
+        add(s, obj[i].name, obj[i].value);
+      }
+    } else {
+      for (key in obj) {
+        buildParams(key, obj[key]);
+      }
+    }
+    return s;
+  }
+
+  return buildParams('', queryParamsObject).join('&').replace(/%20/g, '+');
+}
+
+/**
+ * Part of the `serializeQueryParams` helper function.
+ * @param {Array} s
+ * @param {String} k
+ * @param {String} v
+ */
+function add(s, k, v) {
+  // Strip out keys with undefined or null values (mimics jQuery.ajax).
+  if (v === undefined) {
+    return;
+  }
+
+  v = typeof v === 'function' ? v() : v;
+  s[s.length] = `${encodeURIComponent(k)}=${encodeURIComponent(v)}`;
+}

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -8,7 +8,6 @@ import {
 import AdapterFetchMixin, {
   mungOptionsForFetch,
   headersToObject,
-  serializeQueryParams,
   determineBodyPromise
 } from 'ember-fetch/mixins/adapter-fetch';
 
@@ -341,46 +340,7 @@ test('headersToObject returns an empty object if no headers are passed to it', f
   assert.deepEqual(headerObject, {});
 });
 
-test('serializeQueryParams turns deeply nested objects into queryParams like $.param', function (assert) {
-  assert.expect(1);
 
-  const body = {
-    a: 1,
-    b: 2,
-    c: {
-      d: 3,
-      e: {
-        f: 4
-      },
-      g: [5,6,7]
-    }
-  };
-  const queryParamString = serializeQueryParams(body);
-
-  assert.equal(queryParamString, 'a=1&b=2&c%5Bd%5D=3&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7');
-});
-
-test('serializeQueryParams does not serialize keys with undefined values', function (assert) {
-  assert.expect(1);
-
-  const body = {
-    a: undefined,
-    b: 2,
-    c: {
-      d: undefined,
-      e: {
-        f: 4
-      },
-      g: [5,6,7]
-    },
-    h: null,
-    i: 0,
-    j: false
-  };
-  const queryParamString = serializeQueryParams(body);
-
-  assert.equal(queryParamString, 'b=2&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7&h=null&i=0&j=false');
-});
 
 test('determineBodyResponse returns the body when it is present', function(assert) {
   assert.expect(1);

--- a/tests/unit/utils/serialize-query-params-test.js
+++ b/tests/unit/utils/serialize-query-params-test.js
@@ -1,0 +1,46 @@
+import { module, test } from 'qunit';
+import serializeQueryParams from 'ember-fetch/utils/serialize-query-params';
+
+module('Unit | Utils | serializeQueryParams');
+
+test('serializeQueryParams turns deeply nested objects into queryParams like $.param', function (assert) {
+  assert.expect(1);
+  
+  const body = {
+    a: 1,
+    b: 2,
+    c: {
+      d: 3,
+      e: {
+        f: 4
+      },
+      g: [5,6,7]
+    }
+  };
+  const queryParamString = serializeQueryParams(body);
+  
+  assert.equal(queryParamString, 'a=1&b=2&c%5Bd%5D=3&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7');
+});
+  
+test('serializeQueryParams does not serialize keys with undefined values', function (assert) {
+  assert.expect(1);
+
+  const body = {
+    a: undefined,
+    b: 2,
+    c: {
+      d: undefined,
+      e: {
+        f: 4
+      },
+      g: [5,6,7]
+    },
+    h: null,
+    i: 0,
+    j: false
+  };
+
+  const queryParamString = serializeQueryParams(body);
+
+  assert.equal(queryParamString, 'b=2&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7&h=null&i=0&j=false');
+});


### PR DESCRIPTION
I am working now on an app migrating from `ember-ajax` and this is the main problem I had. This is a backward compatible change as `ember-fetch/ajax` currently will ignore `options.data`. This could be an opportunity to add a `dataType` option to it and default to `json` and `JSON.serialize` `options.data`. This is all backward compatible but will help a lot with migrations.

Before I write more code and more tests, what would be the general feeling about this?