### PR TITLE
Switch typings to ES-style module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Toran Billups <https://github.com/toranb>
 // TypeScript Version: 2.3
 
-export = fetch;
-
-declare namespace fetch {
+declare module 'fetch' {
   export default function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 }


### PR DESCRIPTION
In ember-fetch, we're never using the old/Node-style imports that `export =` is meant to support. We just need to declare the module name, and this works as expected. (I've tested locally in my own app.)