### PR TITLE
Try to fix Travis tests

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -25,8 +25,10 @@ module.exports = {
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
-        '--window-size=1440,900'
-      ]
+        '--window-size=1440,900',
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null,
+      ].filter(Boolean)
     }
   }
 };


### PR DESCRIPTION
Travis tests are failing with an error about sandbox permissions.

[Failing job](https://travis-ci.org/ember-cli/ember-fetch/jobs/338158266)
```
not ok 1 Chrome - error
    ---
        message: >
            Error: Browser exited unexpectedly
            Non-zero exit code: null
            Stderr: 
             [0206/191937.229848:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/google/chrome/chrome-sandbox is owned by root and has mode 4755.
```

According to [this Travis CI doc](https://github.com/travis-ci/docs-travis-ci-com/blob/c1da4af0b7ee5de35fa4490fa8e0fc4b44881089/user/chrome.md#sandboxing), we should be running `--no-sandbox`