### PR TITLE
Change serializeQueryParams behavior to match jQuery.

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -60,9 +60,12 @@ export function serializeQueryParams(queryParamsObject) {
  * @param {String} v
  */
 function add(s, k, v) {
-  // Strip out keys with undefined or null values (mimics jQuery.ajax).
+  // Strip out keys with undefined value and replace null values with
+  // empty strings (mimics jQuery.ajax)
   if (v === undefined) {
     return;
+  } else if (v === null) {
+    v = '';
   }
 
   v = typeof v === 'function' ? v() : v;

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -379,7 +379,7 @@ test('serializeQueryParams does not serialize keys with undefined values', funct
   };
   const queryParamString = serializeQueryParams(body);
 
-  assert.equal(queryParamString, 'b=2&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7&h=null&i=0&j=false');
+  assert.equal(queryParamString, 'b=2&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7&h=&i=0&j=false');
 });
 
 test('determineBodyResponse returns the body when it is present', function(assert) {


### PR DESCRIPTION
A correction to PR #50 and #66 (cc: @nlfurniss).

```js
// jQuery.ajax (tested on 1.11.3, and 3.0)
let body = {
  a: undefined,
  b: null,
  c: 'test'
};

// pretty much what $.ajax does with params
let r = $.ajaxSetup({}, { data: body });
r = $.param(r.data);

console.log(r); // "b=&c=test"
```