### PR TITLE
Add a missing fastboot dependencies whitelist entry.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "configPath": "tests/dummy/config",
     "fastbootDependencies": [
       "node-fetch",
-      "abortcontroller-polyfill"
+      "abortcontroller-polyfill/dist/cjs-ponyfill"
     ]
   }
 }


### PR DESCRIPTION
Fixes an error (introduced in #112) that occurs whenever a fastboot-enabled app that uses ember-fetch tries to handle a request:

```
There was an error running your app in fastboot. More info about the error:
 Error: Unable to require module 'abortcontroller-polyfill/dist/cjs-ponyfill' because it was not in the whitelist.
    at Object.require (/app/node_modules/fastboot/src/ember-app.js:133:15)
    at Module.callback (/app/tmp/broccoli_merge_trees-output_path-76mgNO0Y.tmp/ember-fetch/fastboot-fetch.js:4:44)
```
