### PR TITLE
fix(build): disable source map generation for concatenation

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,8 @@ function treeForBrowserFetch() {
   var expandedAbortcontrollerPath = expand(abortcontrollerPath, 'abortcontroller-polyfill-only.js');
 
   var polyfillTree = concat(new MergeTrees([find(expandedFetchPath), find(expandedAbortcontrollerPath)]), {
-    outputFile: 'ember-fetch.js'
+    outputFile: 'ember-fetch.js',
+    sourceMapConfig: { enabled: false }
   });
 
   return new Template(polyfillTree, templatePath, function(content) {


### PR DESCRIPTION
Fixes #119.

When the ember-fetch.js file is eventully pulled into vendor.js and minifcation with source map generation is enabled, a rogue sourceMappingURL comment sneaks in and breaks everything. This PR removes that rogue comment.