### PR TITLE
Add doc for Fastboot nested addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ export default {
 }
 ```
 
-For addon that supports Fastboot, `ember-fetch` should also be listed as a [peer dependency](https://docs.npmjs.com/files/package.json#peerdependencies). 
-This is because Fastboot only invokes top-level addon's `updateFastBootManifest`, thus `ember-fetch` has to be a top-level addon installed by the host app.
+For addon authors, if the addon supports Fastboot mode, `ember-fetch` should also be listed as a [peer dependency](https://docs.npmjs.com/files/package.json#peerdependencies). 
+This is because Fastboot only invokes top-level addon's `updateFastBootManifest` ([defail](https://github.com/ember-fastboot/ember-cli-fastboot/issues/597)), thus `ember-fetch` has to be a top-level addon installed by the host app.
 
 ### Allow native fetch
 `ember-fetch` allows access to native fetch in browser through a build config flag:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ export default {
 }
 ```
 
+For addon that supports Fastboot, `ember-fetch` should also be listed as a [peer dependency](https://docs.npmjs.com/files/package.json#peerdependencies). 
+This is because Fastboot only invokes top-level addon's `updateFastBootManifest`, thus `ember-fetch` has to be a top-level addon installed by the host app.
+
 ### Allow native fetch
 `ember-fetch` allows access to native fetch in browser through a build config flag:
 ```js


### PR DESCRIPTION
For https://github.com/ember-cli/ember-fetch/issues/55 https://github.com/ember-cli/ember-fetch/issues/98.

To encourage host app to install `ember-fetch` seems to be a right thing to do rather than a "workaround".

Any thoughts on this or alternatives? @kratiahuja @stefanpenner 