### PR TITLE
Add babel-core@6 to dep since rollup-plugin-babel has it as peer-dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+5.1.3 / 2018-08-25
+==================
+
+  * Add babel-core 6 to dependency to avoid babel-core 5 being resolved
+
 5.1.2 / 2018-08-23
 ==================
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@xg-wang/whatwg-fetch": "^3.0.0",
     "abortcontroller-polyfill": "^1.1.9",
+    "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
     "broccoli-concat": "^3.2.2",
     "broccoli-merge-trees": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,7 +326,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.26.0:
+babel-core@^6.26.0, babel-core@^6.26.3:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:


### PR DESCRIPTION
babel 5 doesn't support `preset`, explicitly put babel 6 as dep to avoid issues like https://github.com/ember-cli/ember-fetch/issues/127