### PR TITLE
Move serializeQueryParams out of the provided adapter

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -4,73 +4,11 @@ import { assign, merge } from '@ember/polyfills'
 import RSVP from 'rsvp';
 import fetch from 'fetch';
 
+import { serializeQueryParams } from 'ember-fetch/utils/serialize-query-params';
+
 const {
   Logger: { warn }
 } = Ember;
-
-const RBRACKET = /\[\]$/;
-
-/**
- * Helper function that turns the data/body of a request into a query param string.
- * This is directly copied from jQuery.param.
- * @param {Object} queryParamsObject
- * @returns {String}
- */
-export function serializeQueryParams(queryParamsObject) {
-  var s = [];
-
-  function buildParams(prefix, obj) {
-    var i, len, key;
-
-    if (prefix) {
-      if (Array.isArray(obj)) {
-        for (i = 0, len = obj.length; i < len; i++) {
-          if (RBRACKET.test(prefix)) {
-            add(s, prefix, obj[i]);
-          } else {
-            buildParams(prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']', obj[i]);
-          }
-        }
-      } else if (obj && String(obj) === '[object Object]') {
-        for (key in obj) {
-          buildParams(prefix + '[' + key + ']', obj[key]);
-        }
-      } else {
-        add(s, prefix, obj);
-      }
-    } else if (Array.isArray(obj)) {
-      for (i = 0, len = obj.length; i < len; i++) {
-        add(s, obj[i].name, obj[i].value);
-      }
-    } else {
-      for (key in obj) {
-        buildParams(key, obj[key]);
-      }
-    }
-    return s;
-  }
-
-  return buildParams('', queryParamsObject).join('&').replace(/%20/g, '+');
-}
-
-/**
- * Part of the `serializeQueryParams` helper function.
- * @param {Array} s
- * @param {String} k
- * @param {String} v
- */
-function add(s, k, v) {
-  // Strip out keys with undefined value and replace null values with
-  // empty strings (mimics jQuery.ajax)
-  if (v === undefined) {
-    return;
-  } else if (v === null) {
-    v = '';
-  }
-
-  v = typeof v === 'function' ? v() : v;
-  s[s.length] = `${encodeURIComponent(k)}=${encodeURIComponent(v)}`;
-}
 
 /**
  * Helper function to create a plain object from the response's Headers.

--- a/addon/utils/serialize-query-params.js
+++ b/addon/utils/serialize-query-params.js
@@ -1,0 +1,65 @@
+const RBRACKET = /\[\]$/;
+
+/**
+ * Helper function that turns the data/body of a request into a query param string.
+ * This is directly copied from jQuery.param.
+ * @param {Object} queryParamsObject
+ * @returns {String}
+ */
+export function serializeQueryParams(queryParamsObject) {
+  var s = [];
+
+  function buildParams(prefix, obj) {
+    var i, len, key;
+
+    if (prefix) {
+      if (Array.isArray(obj)) {
+        for (i = 0, len = obj.length; i < len; i++) {
+          if (RBRACKET.test(prefix)) {
+            add(s, prefix, obj[i]);
+          } else {
+            buildParams(prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']', obj[i]);
+          }
+        }
+      } else if (obj && String(obj) === '[object Object]') {
+        for (key in obj) {
+          buildParams(prefix + '[' + key + ']', obj[key]);
+        }
+      } else {
+        add(s, prefix, obj);
+      }
+    } else if (Array.isArray(obj)) {
+      for (i = 0, len = obj.length; i < len; i++) {
+        add(s, obj[i].name, obj[i].value);
+      }
+    } else {
+      for (key in obj) {
+        buildParams(key, obj[key]);
+      }
+    }
+    return s;
+  }
+
+  return buildParams('', queryParamsObject).join('&').replace(/%20/g, '+');
+}
+
+/**
+ * Part of the `serializeQueryParams` helper function.
+ * @param {Array} s
+ * @param {String} k
+ * @param {String} v
+ */
+function add(s, k, v) {
+  // Strip out keys with undefined value and replace null values with
+  // empty strings (mimics jQuery.ajax)
+  if (v === undefined) {
+    return;
+  } else if (v === null) {
+    v = '';
+  }
+
+  v = typeof v === 'function' ? v() : v;
+  s[s.length] = `${encodeURIComponent(k)}=${encodeURIComponent(v)}`;
+}
+
+export default serializeQueryParams;

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -6,7 +6,6 @@ import { Headers, Response } from 'fetch';
 import AdapterFetchMixin, {
   mungOptionsForFetch,
   headersToObject,
-  serializeQueryParams,
   determineBodyPromise
 } from 'ember-fetch/mixins/adapter-fetch';
 
@@ -429,53 +428,6 @@ module('Unit | Mixin | adapter-fetch', function(hooks) {
 
     const headerObject = headersToObject();
     assert.deepEqual(headerObject, {});
-  });
-
-  test('serializeQueryParams turns deeply nested objects into queryParams like $.param', function(assert) {
-    assert.expect(1);
-
-    const body = {
-      a: 1,
-      b: 2,
-      c: {
-        d: 3,
-        e: {
-          f: 4
-        },
-        g: [5, 6, 7]
-      }
-    };
-    const queryParamString = serializeQueryParams(body);
-
-    assert.equal(
-      queryParamString,
-      'a=1&b=2&c%5Bd%5D=3&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7'
-    );
-  });
-
-  test('serializeQueryParams does not serialize keys with undefined values', function(assert) {
-    assert.expect(1);
-
-    const body = {
-      a: undefined,
-      b: 2,
-      c: {
-        d: undefined,
-        e: {
-          f: 4
-        },
-        g: [5, 6, 7]
-      },
-      h: null,
-      i: 0,
-      j: false
-    };
-    const queryParamString = serializeQueryParams(body);
-
-    assert.equal(
-      queryParamString,
-      'b=2&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7&h=&i=0&j=false'
-    );
   });
 
   test('determineBodyResponse returns the body when it is present', function(assert) {


### PR DESCRIPTION
This extracts serializeQueryParams from adapter-fetch such that consuming addons and apps can use query param serialization without the need for the adapter. This was extracted so that ember-data can better migrate away from jquery's ajax :)