### PR TITLE
Use package name of AbortController polyfill in whitelisted dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "configPath": "tests/dummy/config",
     "fastbootDependencies": [
       "node-fetch",
+      "abortcontroller-polyfill",
       "abortcontroller-polyfill/dist/cjs-ponyfill"
     ]
   }


### PR DESCRIPTION
This ensures that polyfill will be listed in `dist/package.json`'s `dependencies`
at build, and then properly installed in FastBoot application server.

closes #115, and also closes https://github.com/simplabs/ember-simple-auth/issues/1690, ~~but requires https://github.com/ember-fastboot/fastboot/pull/200~~, using both whitelisted package and module path, which allows to do not wait on the PR, `abortcontroller-polyfill/dist/cjs-ponyfill` can be removed later.