### PR TITLE
Set body to undefined for 204/205/HEAD responses

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -65,9 +65,8 @@ export function mungOptionsForFetch(_options, adapter) {
 }
 /**
  * Function that always attempts to parse the response as json, and if an error is thrown,
- * returns an object with 'data' set to null if the response is
- * a success and has a status code of 204 (No Content) or 205 (Reset Content) or if the request method was 'HEAD',
- * and the plain payload otherwise.
+ * returns `undefined` if the response is successful and has a status code of 204 (No Content),
+ * or 205 (Reset Content) or if the request method was 'HEAD', and the plain payload otherwise.
  * @param {Response} response
  * @param {Object} requestData
  * @returns {Promise}
@@ -82,7 +81,7 @@ export function determineBodyPromise(response, requestData) {
       }
       const status = response.status;
       if (response.ok && (status === 204 || status === 205 || requestData.method === 'HEAD')) {
-        payload = { data: null };
+        payload = undefined;
       } else {
         console.warn('This response was unable to be parsed as json.', payload);
       }

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -452,36 +452,36 @@ module('Unit | Mixin | adapter-fetch', function(hooks) {
     });
   });
 
-  test('determineBodyResponse returns an empty object when the http status code is 204', function(assert) {
+  test('determineBodyResponse returns undefined when the http status code is 204', function(assert) {
     assert.expect(1);
 
     const response = new Response(null, { status: 204 });
     const bodyPromise = determineBodyPromise(response, {});
 
     return bodyPromise.then(body => {
-      assert.deepEqual(body, { data: null });
+      assert.deepEqual(body, undefined);
     });
   });
 
-  test('determineBodyResponse returns an empty object when the http status code is 205', function(assert) {
+  test('determineBodyResponse returns undefined when the http status code is 205', function(assert) {
     assert.expect(1);
 
     const response = new Response(null, { status: 205 });
     const bodyPromise = determineBodyPromise(response, {});
 
     return bodyPromise.then(body => {
-      assert.deepEqual(body, { data: null });
+      assert.deepEqual(body, undefined);
     });
   });
 
-  test("determineBodyResponse returns an empty object when the request method is 'HEAD'", function(assert) {
+  test("determineBodyResponse returns undefined when the request method is 'HEAD'", function(assert) {
     assert.expect(1);
 
     const response = new Response(null, { status: 200 });
     const bodyPromise = determineBodyPromise(response, { method: 'HEAD' });
 
     return bodyPromise.then(body => {
-      assert.deepEqual(body, { data: null });
+      assert.deepEqual(body, undefined);
     });
   });
 


### PR DESCRIPTION
This brings the mixin inline with jQuery.ajax, which correctly returns `undefined` for the body of a 204/205/HEAD response/request since those are not allowed to contain a body.