### PR TITLE
If POST body is a string, don't stringify it

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -50,7 +50,8 @@ export function mungOptionsForFetch(_options, adapter) {
     } else {
       // NOTE: a request's body cannot be an object, so we stringify it if it is.
       // JSON.stringify removes keys with values of `undefined` (mimics jQuery.ajax).
-      options.body = JSON.stringify(options.data);
+      // If the data is already a string, we assume it's already been stringified.
+      options.body = typeof options.data !== 'string' ? JSON.stringify(options.data) : options.data;
     }
   }
 

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -325,7 +325,7 @@ module('Unit | Mixin | adapter-fetch', function(hooks) {
   });
 
   test("mungOptionsForFetch sets the request body correctly when the method is POST and 'data' is a string", function(assert) {
-    assert.expect(2);
+    assert.expect(1);
 
     // Tests stringified objects.
     const stringifiedData = JSON.stringify({ a: 1, b: 2 });
@@ -336,14 +336,8 @@ module('Unit | Mixin | adapter-fetch', function(hooks) {
     };
 
     let options = mungOptionsForFetch(optionsWithStringData, this.basicAdapter);
-    assert.deepEqual(options.body, JSON.stringify(stringifiedData));
-
-    // Tests plain strings.
-    const data = 'foo';
-    optionsWithStringData.data = data;
-
-    options = mungOptionsForFetch(optionsWithStringData, this.JSONAPIAdapter);
-    assert.equal(options.body, JSON.stringify(data));
+    // data should not be stringified twice
+    assert.deepEqual(options.body, stringifiedData);
   });
 
   test('mungOptionsForFetch does not set a request body when the method is GET or HEAD', function(assert) {


### PR DESCRIPTION
If the user passes a string for `options.data`, we should assume it's already been stringified, and not stringify it again