### PR TITLE
refactor(test/prefer-native): use co instead of async fn & run in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ install:
 
 script:
   - yarn lint:js
+  - yarn test:node
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-test-helper": "^1.2.0",
     "chai": "^4.1.2",
+    "co": "^4.6.0",
     "ember-cli": "~3.0.2",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-eslint": "^4.2.1",


### PR DESCRIPTION
Make Node tests runnable on Node 6.

~~Note: does not yet actually run these tests in CI.~~