### PR TITLE
 Use `ember-cli-babel` to transpile vendor tree 

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ const BroccoliDebug = require('broccoli-debug');
 
 const debug = BroccoliDebug.buildDebugCallback('ember-fetch');
 
+// Path to the template that contains the shim wrapper around the browser polyfill
+const TEMPLATE_PATH = path.resolve(__dirname + '/assets/browser-fetch.js.t');
+
 /*
  * The `index.js` file is the main entry point for all Ember CLI addons.  The
  * object we export from this file is turned into an Addon class
@@ -128,8 +131,6 @@ module.exports = {
   }
 };
 
-// Path to the template that contains the shim wrapper around the browser polyfill
-const templatePath = path.resolve(__dirname + '/assets/browser-fetch.js.t');
 
 
 // Returns a tree containing the browser polyfill (from `whatwg-fetch` and `abortcontroller-polyfill`),
@@ -171,7 +172,7 @@ function treeForBrowserFetch() {
     sourceMapConfig: { enabled: false }
   }), 'after-concat');
 
-  return debug(new Template(polyfillNode, templatePath, function(content) {
+  return debug(new Template(polyfillNode, TEMPLATE_PATH, function(content) {
     return {
       moduleBody: content
     };

--- a/index.js
+++ b/index.js
@@ -117,15 +117,20 @@ module.exports = {
     let babelAddon = this.addons.find(addon => addon.name === 'ember-cli-babel');
 
     let browserTree = this.treeForBrowserFetch();
-    let transpiledBrowserTree = debug(babelAddon.transpileTree(browserTree, {
-      'ember-cli-babel': {
-        compileModules: false,
-      },
-    }), 'after-babel');
+    if (babelAddon) {
+      browserTree = debug(babelAddon.transpileTree(browserTree, {
+        'ember-cli-babel': {
+          compileModules: false,
+        },
+      }), 'after-babel');
+
+    } else {
+      this.ui.writeWarnLine('[ember-fetch] Could not find `ember-cli-babel` addon, opting out of transpilation!')
+    }
 
     const preferNative = this.buildConfig.preferNative;
 
-    return debug(map(transpiledBrowserTree, (content) => `if (typeof FastBoot === 'undefined') {
+    return debug(map(browserTree, (content) => `if (typeof FastBoot === 'undefined') {
       var preferNative = ${preferNative};
       ${content}
     }`), 'wrapped');

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
   },
   "dependencies": {
     "abortcontroller-polyfill": "^1.1.9",
-    "babel-core": "^6.26.3",
-    "babel-preset-env": "^1.7.0",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.5",
     "broccoli-merge-trees": "^3.0.0",
@@ -31,7 +29,6 @@
     "broccoli-templater": "^2.0.1",
     "ember-cli-babel": "^6.8.2",
     "node-fetch": "^2.0.0-alpha.9",
-    "rollup-plugin-babel": "^3.0.7",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
     "broccoli-concat": "^3.2.2",
+    "broccoli-debug": "^0.6.5",
     "broccoli-merge-trees": "^3.0.0",
     "broccoli-rollup": "^2.1.1",
     "broccoli-stew": "^2.0.0",

--- a/test/prefer-native-test.js
+++ b/test/prefer-native-test.js
@@ -22,9 +22,13 @@ require('fetch-test');
     beforeEach(function() {
       addon = Object.create(AddonFactory);
       Object.assign(addon, {
+        addons: [],
         buildConfig: {
           preferNative
-        }
+        },
+        ui: {
+          writeWarnLine() {},
+        },
       });
       subject = addon.treeForVendor();
       output = helpers.createBuilder(subject);

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,7 +957,7 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.26.0, babel-core@^6.26.3:
+babel-core@^6.26.0:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
@@ -3703,11 +3703,6 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
-
-estree-walker@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
-  integrity sha1-va/oCVOD2EFNXcLs9MkXO225QS4=
 
 estree-walker@^0.5.2:
   version "0.5.2"
@@ -7234,21 +7229,6 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
   integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
-
-rollup-plugin-babel@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.7.tgz#5b13611f1ab8922497e9d15197ae5d8a23fe3b1e"
-  integrity sha512-bVe2y0z/V5Ax1qU8NX/0idmzIwJPdUGu8Xx3vXH73h0yGjxfv2gkFI82MBVg49SlsFlLTBadBHb67zy4TWM3hA==
-  dependencies:
-    rollup-pluginutils "^1.5.0"
-
-rollup-pluginutils@^1.5.0:
-  version "1.5.2"
-  resolved "http://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
-  integrity sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=
-  dependencies:
-    estree-walker "^0.2.1"
-    minimatch "^3.0.2"
 
 rollup-pluginutils@^2.0.1:
   version "2.3.3"


### PR DESCRIPTION
This should fix #156 and now also skips some transpilation steps if `config/targets.js` is configured to e.g. support native ES6 classes.

Closes #163 (no longer necessary)

@dbouwman @buschtoens can you test this in your app please? 🙏 

/cc @xg-wang @rwjblue 