### PR TITLE
Make configuration work in engines

### DIFF
--- a/test/prefer-native-test.js
+++ b/test/prefer-native-test.js
@@ -23,7 +23,7 @@ require('fetch-test');
       addon = Object.create(AddonFactory);
       Object.assign(addon, {
         addons: [],
-        buildConfig: {
+        _fetchBuildConfig: {
           preferNative
         },
         ui: {
@@ -48,6 +48,184 @@ require('fetch-test');
     it(`${
       preferNative ? 'Prefers' : "Doesn't prefer"
     } native fetch as specified`, co.wrap(function*() {
+      yield output.build();
+      let emberFetchCode = output.read()['ember-fetch.js'];
+      const amdLoaderCode = fs.readFileSync(require.resolve('loader.js'));
+      const sandbox = {
+        __result: false,
+        window: {
+          fetch: function() {
+            sandbox.__result = true;
+          },
+          Ember: { RSVP }
+        }
+      };
+      vm.createContext(sandbox);
+      const code = amdLoaderCode + emberFetchCode + testCode;
+      vm.runInContext(code, sandbox);
+      expect(sandbox.__result).to.equal(preferNative);
+    }));
+
+    if (preferNative === true) {
+      it('Has fetch poly fill even if fetch is not there', co.wrap(function*() {
+        yield output.build();
+        let emberFetchCode = output.read()['ember-fetch.js'];
+        const amdLoaderCode = fs.readFileSync(require.resolve('loader.js'));
+        const sandbox = {
+          console,
+          window: {
+            __result: false,
+            // no fetch here
+            // fetch: function() {},
+            Ember: { RSVP }
+          }
+        };
+        vm.createContext(sandbox);
+        const testCodeForNonFetch = `
+          define('fetch-test', ['fetch'], function(_fetch) {
+            if (_fetch.default.polyfill) {
+              window.__result = true
+            }
+          });
+          require('fetch-test');
+        `;
+        const code = amdLoaderCode + emberFetchCode + testCodeForNonFetch;
+        vm.runInContext(code, sandbox);
+        expect(sandbox.window.__result).to.equal(true);
+      }))
+    }
+  });
+
+  describe(`Build browser assets with preferNative = ${preferNative} in nested dependencies`, function() {
+    let output, subject, addon;
+
+    beforeEach(function() {
+      addon = Object.create(AddonFactory);
+
+      let app = {
+        _fetchBuildConfig: {
+          preferNative
+        }
+      };
+
+      Object.assign(addon, {
+        addons: [],
+        _findHost() {
+          return app;
+        },
+        ui: {
+          writeWarnLine() {},
+        },
+      });
+      subject = addon.treeForVendor();
+      output = helpers.createBuilder(subject);
+    });
+
+    afterEach(co.wrap(function* () {
+      yield output.dispose();
+    }));
+
+    it('preferNative is built into vendor file', co.wrap(function*() {
+      yield output.build();
+      let files = output.read();
+      expect(files).to.have.all.keys('ember-fetch.js');
+      expect(files['ember-fetch.js']).to.include(`var preferNative = ${preferNative}`);
+    }));
+
+    it(`${
+      preferNative ? 'Prefers' : "Doesn't prefer"
+      } native fetch as specified`, co.wrap(function*() {
+      yield output.build();
+      let emberFetchCode = output.read()['ember-fetch.js'];
+      const amdLoaderCode = fs.readFileSync(require.resolve('loader.js'));
+      const sandbox = {
+        __result: false,
+        window: {
+          fetch: function() {
+            sandbox.__result = true;
+          },
+          Ember: { RSVP }
+        }
+      };
+      vm.createContext(sandbox);
+      const code = amdLoaderCode + emberFetchCode + testCode;
+      vm.runInContext(code, sandbox);
+      expect(sandbox.__result).to.equal(preferNative);
+    }));
+
+    if (preferNative === true) {
+      it('Has fetch poly fill even if fetch is not there', co.wrap(function*() {
+        yield output.build();
+        let emberFetchCode = output.read()['ember-fetch.js'];
+        const amdLoaderCode = fs.readFileSync(require.resolve('loader.js'));
+        const sandbox = {
+          console,
+          window: {
+            __result: false,
+            // no fetch here
+            // fetch: function() {},
+            Ember: { RSVP }
+          }
+        };
+        vm.createContext(sandbox);
+        const testCodeForNonFetch = `
+          define('fetch-test', ['fetch'], function(_fetch) {
+            if (_fetch.default.polyfill) {
+              window.__result = true
+            }
+          });
+          require('fetch-test');
+        `;
+        const code = amdLoaderCode + emberFetchCode + testCodeForNonFetch;
+        vm.runInContext(code, sandbox);
+        expect(sandbox.window.__result).to.equal(true);
+      }))
+    }
+  });
+
+  describe(`Build browser assets with preferNative = ${preferNative} in nested dependencies without _findHost`, function() {
+    let output, subject, addon;
+
+    beforeEach(function() {
+      addon = Object.create(AddonFactory);
+
+      let app = {
+        _fetchBuildConfig: {
+          preferNative
+        }
+      };
+
+      Object.assign(addon, {
+        addons: [],
+        app: this,
+        parent: {
+          parent: {
+            app,
+            parent: {}
+          }
+        },
+        ui: {
+          writeWarnLine() {},
+        },
+      });
+      subject = addon.treeForVendor();
+      output = helpers.createBuilder(subject);
+    });
+
+    afterEach(co.wrap(function* () {
+      yield output.dispose();
+    }));
+
+    it('preferNative is built into vendor file', co.wrap(function*() {
+      yield output.build();
+      let files = output.read();
+      expect(files).to.have.all.keys('ember-fetch.js');
+      expect(files['ember-fetch.js']).to.include(`var preferNative = ${preferNative}`);
+    }));
+
+    it(`${
+      preferNative ? 'Prefers' : "Doesn't prefer"
+      } native fetch as specified`, co.wrap(function*() {
       yield output.build();
       let emberFetchCode = output.read()['ember-fetch.js'];
       const amdLoaderCode = fs.readFileSync(require.resolve('loader.js'));


### PR DESCRIPTION
This makes sure that all nested dependencies use the correct application configuration, and that the import/configuration works in nested addons, especially in engines.

This fixes #133.

I tried it in an app of ours with engines & nested dependencies to ember-fetch, and this ensures that it always got the correct options passed.

Note: While investigating this, I also found out that it wasn't even taking the correct options for building. E.g. If, in my engines dummy app, I had `preferNative: true` specified in the `ember-cli-build.js`, it never actually got to this value, instead reading the config from ember-fetch's config (somehow? not entirely sure).