### PR TITLE
Do not include polyfill if browser targets don't need it

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ otherwise the polyfilled `fetch` will be installed during the first pass of the 
 
 If set to `false`, the polyfilled `fetch` will replace native `fetch` be there or not.
 
-If all your browser targets (defined in `config/targets.js`) support native `fetch`, and `preferNative: true`, the polyfill will not be included in the output build. If, for some reason, you still need the polyfill to be included in the bundle, you can set `alwaysIncludePolyfill: true`.
+If all your [browser targets](https://guides.emberjs.com/release/configuring-ember/build-targets/) support native `fetch`, and `preferNative: true`, the polyfill will not be included in the output build. If, for some reason, you still need the polyfill to be included in the bundle, you can set `alwaysIncludePolyfill: true`.
 
 The way you do import remains same.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ otherwise the polyfilled `fetch` will be installed during the first pass of the 
 
 If set to `false`, the polyfilled `fetch` will replace native `fetch` be there or not.
 
+If all your browser targets (defined in `config/targets.js`) support native `fetch`, and `preferNative: true`, the polyfill will not be included in the output build. If, for some reason, you still need the polyfill to be included in the bundle, you can set `alwaysIncludePolyfill: true`.
+
 The way you do import remains same.
 
 ## Browser Support

--- a/assets/browser-fetch.js.t
+++ b/assets/browser-fetch.js.t
@@ -33,6 +33,10 @@
 
     <%= moduleBody %>
 
+    if (!self.fetch) {
+      throw new Error('fetch is not defined - maybe your browser targets are not covering everything you need?');
+    }
+
     var pending = 0;
     function decrement(result) {
       pending--;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "broccoli-stew": "^2.0.0",
     "broccoli-templater": "^2.0.1",
     "calculate-cache-key-for-tree": "^1.1.0",
+    "caniuse-api": "^3.0.0",
     "ember-cli-babel": "^6.8.2",
     "node-fetch": "^2.3.0",
     "whatwg-fetch": "^3.0.0"

--- a/test/browsers-target-test.js
+++ b/test/browsers-target-test.js
@@ -40,7 +40,7 @@ describe(`Do not include the polyfill if the browser targets match`, function() 
 
 });
 
-describe(`Force preferNative to true if the polyfill is not included`, function() {
+describe(`Ignore target browsers if preferNative is false`, function() {
   let output, subject, addon;
 
   beforeEach(function() {
@@ -68,9 +68,9 @@ describe(`Force preferNative to true if the polyfill is not included`, function(
     yield output.build();
     let files = output.read();
     expect(files).to.have.all.keys('ember-fetch.js');
-    expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
-    expect(files['ember-fetch.js']).to.not.include(`fetch.polyfill = true`);
-    expect(files['ember-fetch.js']).to.not.include(`class AbortController`);
+    expect(files['ember-fetch.js']).to.include(`var preferNative = false`);
+    expect(files['ember-fetch.js']).to.include(`fetch.polyfill = true`);
+    expect(files['ember-fetch.js']).to.include(`class AbortController`);
   }));
 
 });
@@ -83,7 +83,7 @@ describe(`Include the polyfill if the browser targets do not match`, function() 
     Object.assign(addon, {
       addons: [],
       _fetchBuildConfig: {
-        preferNative: false,
+        preferNative: true,
         browsers: ['ie 11']
       },
       ui: {
@@ -103,7 +103,7 @@ describe(`Include the polyfill if the browser targets do not match`, function() 
     yield output.build();
     let files = output.read();
     expect(files).to.have.all.keys('ember-fetch.js');
-    expect(files['ember-fetch.js']).to.include(`var preferNative = false`);
+    expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
     expect(files['ember-fetch.js']).to.include(`fetch.polyfill = true`);
     expect(files['ember-fetch.js']).to.include(`class AbortController`);
   }));
@@ -118,7 +118,7 @@ describe(`Include the abortcontroller polyfill only if the browser targets suppo
     Object.assign(addon, {
       addons: [],
       _fetchBuildConfig: {
-        preferNative: false,
+        preferNative: true,
         browsers: ['safari 11']
       },
       ui: {
@@ -153,7 +153,7 @@ describe(`Include the polyfill if alwaysIncludePolyfill=true`, function() {
     Object.assign(addon, {
       addons: [],
       _fetchBuildConfig: {
-        preferNative: false,
+        preferNative: true,
         alwaysIncludePolyfill: true,
         browsers: ['last 1 chrome versions']
       },
@@ -174,7 +174,7 @@ describe(`Include the polyfill if alwaysIncludePolyfill=true`, function() {
     yield output.build();
     let files = output.read();
     expect(files).to.have.all.keys('ember-fetch.js');
-    expect(files['ember-fetch.js']).to.include(`var preferNative = false`);
+    expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
     expect(files['ember-fetch.js']).to.include(`fetch.polyfill = true`);
     expect(files['ember-fetch.js']).to.include(`class AbortController`);
   }));

--- a/test/browsers-target-test.js
+++ b/test/browsers-target-test.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect;
 const helpers = require('broccoli-test-helper');
 const co = require('co');
 
-describe(`Include the polyfill if the browser targets match`, function() {
+describe(`Do not include the polyfill if the browser targets match`, function() {
   let output, subject, addon;
 
   beforeEach(function() {
@@ -35,6 +35,7 @@ describe(`Include the polyfill if the browser targets match`, function() {
     expect(files).to.have.all.keys('ember-fetch.js');
     expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
     expect(files['ember-fetch.js']).to.not.include(`fetch.polyfill = true`);
+    expect(files['ember-fetch.js']).to.not.include(`class AbortController`);
   }));
 
 });
@@ -69,6 +70,7 @@ describe(`Force preferNative to true if the polyfill is not included`, function(
     expect(files).to.have.all.keys('ember-fetch.js');
     expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
     expect(files['ember-fetch.js']).to.not.include(`fetch.polyfill = true`);
+    expect(files['ember-fetch.js']).to.not.include(`class AbortController`);
   }));
 
 });
@@ -103,6 +105,78 @@ describe(`Include the polyfill if the browser targets do not match`, function() 
     expect(files).to.have.all.keys('ember-fetch.js');
     expect(files['ember-fetch.js']).to.include(`var preferNative = false`);
     expect(files['ember-fetch.js']).to.include(`fetch.polyfill = true`);
+    expect(files['ember-fetch.js']).to.include(`class AbortController`);
+  }));
+
+});
+
+describe(`Include the abortcontroller polyfill only if the browser targets support fetch only`, function() {
+  let output, subject, addon;
+
+  beforeEach(function() {
+    addon = Object.create(AddonFactory);
+    Object.assign(addon, {
+      addons: [],
+      _fetchBuildConfig: {
+        preferNative: false,
+        browsers: ['safari 11']
+      },
+      ui: {
+        writeWarnLine() {
+        }
+      }
+    });
+    subject = addon.treeForVendor();
+    output = helpers.createBuilder(subject);
+  });
+
+  afterEach(co.wrap(function* () {
+    yield output.dispose();
+  }));
+
+  it('preferNative is built into vendor file', co.wrap(function* () {
+    yield output.build();
+    let files = output.read();
+    expect(files).to.have.all.keys('ember-fetch.js');
+    expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
+    expect(files['ember-fetch.js']).to.not.include(`fetch.polyfill = true`);
+    expect(files['ember-fetch.js']).to.include(`class AbortController`);
+  }));
+
+});
+
+describe(`Include the polyfill if alwaysIncludePolyfill=true`, function() {
+  let output, subject, addon;
+
+  beforeEach(function() {
+    addon = Object.create(AddonFactory);
+    Object.assign(addon, {
+      addons: [],
+      _fetchBuildConfig: {
+        preferNative: false,
+        alwaysIncludePolyfill: true,
+        browsers: ['last 1 chrome versions']
+      },
+      ui: {
+        writeWarnLine() {
+        }
+      }
+    });
+    subject = addon.treeForVendor();
+    output = helpers.createBuilder(subject);
+  });
+
+  afterEach(co.wrap(function* () {
+    yield output.dispose();
+  }));
+
+  it('preferNative is built into vendor file', co.wrap(function* () {
+    yield output.build();
+    let files = output.read();
+    expect(files).to.have.all.keys('ember-fetch.js');
+    expect(files['ember-fetch.js']).to.include(`var preferNative = false`);
+    expect(files['ember-fetch.js']).to.include(`fetch.polyfill = true`);
+    expect(files['ember-fetch.js']).to.include(`class AbortController`);
   }));
 
 });

--- a/test/browsers-target-test.js
+++ b/test/browsers-target-test.js
@@ -14,6 +14,7 @@ describe(`Do not include the polyfill if the browser targets match`, function() 
       addons: [],
       _fetchBuildConfig: {
         preferNative: true,
+        alwaysIncludePolyfill: false,
         browsers: ['last 1 chrome versions']
       },
       ui: {
@@ -29,7 +30,7 @@ describe(`Do not include the polyfill if the browser targets match`, function() 
     yield output.dispose();
   }));
 
-  it('preferNative is built into vendor file', co.wrap(function* () {
+  it('fetch & AbortController polyfills are not included', co.wrap(function* () {
     yield output.build();
     let files = output.read();
     expect(files).to.have.all.keys('ember-fetch.js');
@@ -49,6 +50,7 @@ describe(`Ignore target browsers if preferNative is false`, function() {
       addons: [],
       _fetchBuildConfig: {
         preferNative: false,
+        alwaysIncludePolyfill: false,
         browsers: ['last 1 chrome versions']
       },
       ui: {
@@ -64,7 +66,7 @@ describe(`Ignore target browsers if preferNative is false`, function() {
     yield output.dispose();
   }));
 
-  it('preferNative is built into vendor file', co.wrap(function* () {
+  it('fetch & AbortController polyfills are included', co.wrap(function* () {
     yield output.build();
     let files = output.read();
     expect(files).to.have.all.keys('ember-fetch.js');
@@ -84,6 +86,7 @@ describe(`Include the polyfill if the browser targets do not match`, function() 
       addons: [],
       _fetchBuildConfig: {
         preferNative: true,
+        alwaysIncludePolyfill: false,
         browsers: ['ie 11']
       },
       ui: {
@@ -99,7 +102,7 @@ describe(`Include the polyfill if the browser targets do not match`, function() 
     yield output.dispose();
   }));
 
-  it('preferNative is built into vendor file', co.wrap(function* () {
+  it('fetch & AbortController polyfills are included', co.wrap(function* () {
     yield output.build();
     let files = output.read();
     expect(files).to.have.all.keys('ember-fetch.js');
@@ -119,6 +122,7 @@ describe(`Include the abortcontroller polyfill only if the browser targets suppo
       addons: [],
       _fetchBuildConfig: {
         preferNative: true,
+        alwaysIncludePolyfill: false,
         browsers: ['safari 11']
       },
       ui: {
@@ -134,7 +138,7 @@ describe(`Include the abortcontroller polyfill only if the browser targets suppo
     yield output.dispose();
   }));
 
-  it('preferNative is built into vendor file', co.wrap(function* () {
+  it('AbortController polyfill is included', co.wrap(function* () {
     yield output.build();
     let files = output.read();
     expect(files).to.have.all.keys('ember-fetch.js');
@@ -170,7 +174,7 @@ describe(`Include the polyfill if alwaysIncludePolyfill=true`, function() {
     yield output.dispose();
   }));
 
-  it('preferNative is built into vendor file', co.wrap(function* () {
+  it('fetch & AbortController polyfills are included', co.wrap(function* () {
     yield output.build();
     let files = output.read();
     expect(files).to.have.all.keys('ember-fetch.js');

--- a/test/browsers-target-test.js
+++ b/test/browsers-target-test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const AddonFactory = require('../');
+const expect = require('chai').expect;
+const helpers = require('broccoli-test-helper');
+const co = require('co');
+
+describe(`Include the polyfill if the browser targets match`, function() {
+  let output, subject, addon;
+
+  beforeEach(function() {
+    addon = Object.create(AddonFactory);
+    Object.assign(addon, {
+      addons: [],
+      _fetchBuildConfig: {
+        preferNative: true,
+        browsers: ['last 1 chrome versions']
+      },
+      ui: {
+        writeWarnLine() {
+        }
+      }
+    });
+    subject = addon.treeForVendor();
+    output = helpers.createBuilder(subject);
+  });
+
+  afterEach(co.wrap(function* () {
+    yield output.dispose();
+  }));
+
+  it('preferNative is built into vendor file', co.wrap(function* () {
+    yield output.build();
+    let files = output.read();
+    expect(files).to.have.all.keys('ember-fetch.js');
+    expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
+    expect(files['ember-fetch.js']).to.not.include(`fetch.polyfill = true`);
+  }));
+
+});
+
+describe(`Force preferNative to true if the polyfill is not included`, function() {
+  let output, subject, addon;
+
+  beforeEach(function() {
+    addon = Object.create(AddonFactory);
+    Object.assign(addon, {
+      addons: [],
+      _fetchBuildConfig: {
+        preferNative: false,
+        browsers: ['last 1 chrome versions']
+      },
+      ui: {
+        writeWarnLine() {
+        }
+      }
+    });
+    subject = addon.treeForVendor();
+    output = helpers.createBuilder(subject);
+  });
+
+  afterEach(co.wrap(function* () {
+    yield output.dispose();
+  }));
+
+  it('preferNative is built into vendor file', co.wrap(function* () {
+    yield output.build();
+    let files = output.read();
+    expect(files).to.have.all.keys('ember-fetch.js');
+    expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
+    expect(files['ember-fetch.js']).to.not.include(`fetch.polyfill = true`);
+  }));
+
+});
+
+describe(`Include the polyfill if the browser targets do not match`, function() {
+  let output, subject, addon;
+
+  beforeEach(function() {
+    addon = Object.create(AddonFactory);
+    Object.assign(addon, {
+      addons: [],
+      _fetchBuildConfig: {
+        preferNative: false,
+        browsers: ['ie 11']
+      },
+      ui: {
+        writeWarnLine() {
+        }
+      }
+    });
+    subject = addon.treeForVendor();
+    output = helpers.createBuilder(subject);
+  });
+
+  afterEach(co.wrap(function* () {
+    yield output.dispose();
+  }));
+
+  it('preferNative is built into vendor file', co.wrap(function* () {
+    yield output.build();
+    let files = output.read();
+    expect(files).to.have.all.keys('ember-fetch.js');
+    expect(files['ember-fetch.js']).to.include(`var preferNative = false`);
+    expect(files['ember-fetch.js']).to.include(`fetch.polyfill = true`);
+  }));
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,7 +2224,7 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
-browserslist@^4.1.0:
+browserslist@^4.0.0, browserslist@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.4.tgz#4477b737db6a1b07077275b24791e680d4300425"
   integrity sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==
@@ -2384,6 +2384,21 @@ can-symlink@^1.0.0:
   integrity sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=
   dependencies:
     tmp "0.0.28"
+
+caniuse-api@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
+  integrity sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
+  dependencies:
+    browserslist "^4.0.0"
+    caniuse-lite "^1.0.0"
+    lodash.memoize "^4.1.2"
+    lodash.uniq "^4.5.0"
+
+caniuse-lite@^1.0.0:
+  version "1.0.30000911"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000911.tgz#5dfb8139ee479722da27000ca92dec47913b9605"
+  integrity sha512-x/E/SNwD80I0bT+fF9Y3Kbwo7Xd1xSafCAmFlpJmaVg3SQoJJOH4Ivb9fi9S0WjfqewQ6Ydt1zEVZpmMVYNeDA==
 
 caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000899:
   version "1.0.30000907"
@@ -6138,6 +6153,11 @@ lodash.keys@~2.3.0:
     lodash._shimkeys "~2.3.0"
     lodash.isobject "~2.3.0"
 
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.merge@^4.3.1, lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
@@ -6201,7 +6221,7 @@ lodash.templatesettings@~2.3.0:
     lodash._reinterpolate "~2.3.0"
     lodash.escape "~2.3.0"
 
-lodash.uniq@^4.2.0:
+lodash.uniq@^4.2.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,13 +2225,13 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.0.0, browserslist@^4.1.0:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.4.tgz#4477b737db6a1b07077275b24791e680d4300425"
-  integrity sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.6.tgz#0f9d9081afc66b36f477c6bdf3813f784f42396a"
+  integrity sha512-kMGKs4BTzRWviZ8yru18xBpx+CyHG9eqgRbj9XbE3IMgtczf4aiA0Y1YCpVdvUieKGZ03kolSPXqTcscBCb9qw==
   dependencies:
-    caniuse-lite "^1.0.30000899"
-    electron-to-chromium "^1.3.82"
-    node-releases "^1.0.1"
+    caniuse-lite "^1.0.30000921"
+    electron-to-chromium "^1.3.92"
+    node-releases "^1.1.1"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -2395,15 +2395,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0:
-  version "1.0.30000911"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000911.tgz#5dfb8139ee479722da27000ca92dec47913b9605"
-  integrity sha512-x/E/SNwD80I0bT+fF9Y3Kbwo7Xd1xSafCAmFlpJmaVg3SQoJJOH4Ivb9fi9S0WjfqewQ6Ydt1zEVZpmMVYNeDA==
-
-caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000899:
-  version "1.0.30000907"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000907.tgz#0b9899bde53fb1c30e214fb12402361e02ff5c42"
-  integrity sha512-No5sQ/OB2Nmka8MNOOM6nJx+Hxt6MQ6h7t7kgJFu9oTuwjykyKRSBP/+i/QAyFHxeHB+ddE0Da1CG5ihx9oehQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000921:
+  version "1.0.30000921"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000921.tgz#7a607c1623444b22351d834e093aedda3c42fbe8"
+  integrity sha512-Bu09ciy0lMWLgpYC77I0YGuI8eFRBPPzaSOYJK1jTI64txCphYCqnWbxJYjHABYVt/TYX/p3jNjLBR87u1Bfpw==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -3128,10 +3123,15 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.82:
+electron-to-chromium@^1.3.47:
   version "1.3.84"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz#2e55df59e818f150a9f61b53471ebf4f0feecc65"
   integrity sha512-IYhbzJYOopiTaNWMBp7RjbecUBsbnbDneOP86f3qvS0G0xfzwNSvMJpTrvi5/Y1gU7tg2NAgeg8a8rCYvW9Whw==
+
+electron-to-chromium@^1.3.92:
+  version "1.3.92"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.92.tgz#9027b5abaea400045edd652c0e4838675c814399"
+  integrity sha512-En051LMzMl3/asMWGZEtU808HOoVWIpmmZx1Ep8N+TT9e7z/X8RcLeBU2kLSNLGQ+5SuKELzMx+MVuTBXk6Q9w==
 
 ember-assign-polyfill@~2.4.0:
   version "2.4.0"
@@ -6810,10 +6810,10 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.3.tgz#3414ed84595096459c251699bfcb47d88324a9e4"
-  integrity sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==
+node-releases@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.1.tgz#8fff8aea1cfcad1fb4205f805149054fbf73cafd"
+  integrity sha512-2UXrBr6gvaebo5TNF84C66qyJJ6r0kxBObgZIDX3D3/mt1ADKiHux3NJPWisq0wxvJJdkjECH+9IIKYViKj71Q==
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
This is my stab at fixing #45.

If the target browsers all support native fetch, this will avoid importing the polyfill(s) and just setup the exports, so that you can continue using `import fetch from 'fetch';` with no code changes.

By default, it will use your specified target browsers, but you can also override this in the options, e.g.:

```js
'ember-fetch': {
  preferNative: true,
  browers: ['ie 11']
}
```

If no browsers are found at all, it will always include the polyfill.

This PR is on top of #172 , as I could not get to the configuration via `this.buildConfig` in the `treeForBrowserFetch` method.

If you have any suggestions for improvements, I'd be happy to try to implement them - To be honest, it was a bit tricky to implement this, so there might be better ways to do some things.

As a sidenote, I wasted some time until I figured out that the polyfill is included in development environment even if it shouldn't (due to the browser targets), as `ember-cli-pretender` will _also_ include the polyfill in development/test environment. So as long as you have `ember-cli-pretender` installed, you'll need to actually run `ember s --prod` to get a build without the polyfill (if you remove IE 11 from the targets for production).