### PR TITLE
Support POST body of all valid types

### DIFF
--- a/addon/utils/mung-options-for-fetch.js
+++ b/addon/utils/mung-options-for-fetch.js
@@ -12,7 +12,7 @@ export default function mungOptionsForFetch(_options) {
   }, _options);
 
   // Default to 'GET' in case `type` is not passed in (mimics jQuery.ajax).
-  options.method = options.method || options.type || 'GET';
+  options.method = (options.method || options.type || 'GET').toUpperCase();
 
   if (options.data) {
     // GET and HEAD requests can't have a `body`
@@ -24,10 +24,15 @@ export default function mungOptionsForFetch(_options) {
         options.url += `${queryParamDelimiter}${serializeQueryParams(options.data)}`;
       }
     } else {
-      // NOTE: a request's body cannot be an object, so we stringify it if it is.
+      // NOTE: a request's body cannot be a POJO, so we stringify it if it is.
       // JSON.stringify removes keys with values of `undefined` (mimics jQuery.ajax).
-      // If the data is already a string, we assume it's already been stringified.
-      options.body = typeof options.data !== 'string' ? JSON.stringify(options.data) : options.data;
+      // If the data is not a POJO (it's a String, FormData, etc), we just set it.
+      // If the data is a string, we assume it's a stringified object.
+      if (options.data.constructor === Object) {
+        options.body = JSON.stringify(options.data);
+      } else {
+        options.body = options.data;
+      }
     }
   }
 

--- a/tests/unit/utils/mung-options-for-fetch-test.js
+++ b/tests/unit/utils/mung-options-for-fetch-test.js
@@ -172,6 +172,25 @@ module('Unit | mungOptionsForFetch', function() {
     assert.equal(options.method, 'GET');
   });
 
+  test('mungOptionsForFetch sets the method to an uppercase string', function(assert) {
+    assert.expect(2);
+    const getOptions = {
+      url: 'https://emberjs.com',
+      type: 'get',
+    };
+
+    let options = mungOptionsForFetch(getOptions);
+    assert.equal(options.method, 'GET');
+
+    const postOptions = {
+      url: 'https://emberjs.com',
+      method: 'post',
+    };
+
+    options = mungOptionsForFetch(postOptions);
+    assert.equal(options.method, 'POST');
+  });
+
   test('mungOptionsForFetch adds string query params to the url correctly', function(assert) {
     assert.expect(2);
 
@@ -339,5 +358,19 @@ module('Unit | mungOptionsForFetch', function() {
 
     const postOptions = mungOptionsForFetch(postData);
     assert.equal(postOptions.body, '{}', "'options.body' is an empty object");
+  });
+
+  test("mungOptionsForFetch sets the request body correctly when 'data' is FormData", function(assert) {
+    assert.expect(1);
+
+    const formData = new FormData()
+    const postData = {
+      url: 'https://emberjs.com',
+      type: 'POST',
+      data: formData,
+    };
+
+    const postOptions = mungOptionsForFetch(postData);
+    assert.equal(postOptions.body, formData, "'options.body' is the FormData passed in");
   });
 });


### PR DESCRIPTION
Currently `mungOptionsforFetch` only supports String and POJO. This fixes that.

Also add a change that forces `method/type` to uppercase since every time we use it in a conditional we assert against GET/POST/etc.

Please pay special attention to [this line](https://github.com/ember-cli/ember-fetch/compare/master...nlfurniss:support-form-data?expand=1#diff-eb175c7d911802afe9d9b29676a4ce85R31). I'm trying to not build a big switch statement to accomplish this