### PR TITLE
Only set default Content-Type header in adapter mixin

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -38,7 +38,25 @@ export default Mixin.create({
     if (adapterHeaders) {
       options.headers = assign(options.headers || {}, adapterHeaders);
     }
-    return mungOptionsForFetch(options);
+
+    const mungedOptions = mungOptionsForFetch(options);
+
+    // Mimics the default behavior in Ember Data's `ajaxOptions`, namely to set the
+    // 'Content-Type' header to application/json if it is not a GET request and it has a body.
+    if (
+      mungedOptions.method !== 'GET' &&
+      mungedOptions.body &&
+      (mungedOptions.headers === undefined ||
+        !(
+          mungedOptions.headers['Content-Type'] ||
+          mungedOptions.headers['content-type']
+        ))
+    ) {
+      mungedOptions.headers = mungedOptions.headers || {};
+      mungedOptions.headers['Content-Type'] = 'application/json; charset=utf-8';
+    }
+
+    return mungedOptions;
   },
 
   /**

--- a/addon/utils/mung-options-for-fetch.js
+++ b/addon/utils/mung-options-for-fetch.js
@@ -31,12 +31,5 @@ export default function mungOptionsForFetch(_options) {
     }
   }
 
-  // Mimics the default behavior in Ember Data's `ajaxOptions`, namely to set the
-  // 'Content-Type' header to application/json if it is not a GET request and it has a body.
-  if (options.method !== 'GET' && options.body && (options.headers === undefined || !(options.headers['Content-Type'] || options.headers['content-type']))) {
-    options.headers = options.headers || {};
-    options.headers['Content-Type'] = 'application/json; charset=utf-8';
-  }
-
   return options;
 }

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -62,6 +62,120 @@ module('Unit | Mixin | adapter-fetch', function(hooks) {
     );
   });
 
+  test('mixin adds a default "Content-Type" header if none is present', function(assert) {
+    assert.expect(2);
+    const optionsNoHeaders = {
+      url: 'https://emberjs.com',
+      type: 'POST',
+      data: { a: 1 }
+    };
+    const optionsHeadersWithoutContentType = {
+      url: 'https://emberjs.com',
+      type: 'POST',
+      headers: {
+        'X-foo': 'bar'
+      },
+      data: { a: 1 }
+    };
+    let options = this.JSONAPIAdapter.ajaxOptions(optionsNoHeaders.url, optionsNoHeaders.type, optionsNoHeaders);
+    assert.deepEqual(
+      options.headers,
+      {
+        'Content-Type': 'application/json; charset=utf-8',
+        'custom-header': 'foo',
+      },
+      "POST call's options without a headers object now has a headers object which has a content-type header"
+    );
+
+    options = this.JSONAPIAdapter.ajaxOptions(
+      optionsHeadersWithoutContentType.url,
+      optionsHeadersWithoutContentType.type,
+      optionsHeadersWithoutContentType
+    );
+    assert.deepEqual(
+      options.headers,
+      {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-foo': 'bar',
+        'custom-header': 'foo',
+      },
+      "POST call's options with a headers object now has a content-type header"
+    );
+  });
+
+  test('mixin does not add a "Content-Type" header if it is a GET request', function(assert) {
+    assert.expect(1);
+    const getOptions = {
+      url: 'https://emberjs.com',
+      type: 'GET',
+      headers: {
+        foo: 'bar'
+      }
+    };
+
+    let options = this.JSONAPIAdapter.ajaxOptions(getOptions.url, getOptions.type, getOptions);
+    assert.deepEqual(
+      options.headers,
+      {
+        foo: 'bar',
+        'custom-header': 'foo',
+      },
+      "GET call's options has no added content-type header"
+    );
+  });
+
+  test('mixin does not add a "Content-Type" header if a POST request has no body', function(assert) {
+    assert.expect(1);
+    const postNoDataOptions = {
+      url: 'https://emberjs.com',
+      type: 'GET',
+      headers: {
+        foo: 'bar',
+        'custom-header': 'foo',
+      }
+    };
+
+    let options = this.JSONAPIAdapter.ajaxOptions(
+      postNoDataOptions.url,
+      postNoDataOptions.type,
+      postNoDataOptions
+    );
+    assert.deepEqual(
+      options.headers,
+      {
+        foo: 'bar',
+        'custom-header': 'foo',
+      },
+      'POST call with no body has no added content-type header'
+    );
+  });
+
+  test('mixin respects the "Content-Type" header if present', function(assert) {
+    assert.expect(1);
+    const optionsHeadersWithContentType = {
+      url: 'https://emberjs.com',
+      type: 'POST',
+      headers: {
+        'Content-Type': 'application/special-type'
+      },
+      data: { a: 1 }
+    };
+
+    let options = this.JSONAPIAdapter.ajaxOptions(
+      optionsHeadersWithContentType.url,
+      optionsHeadersWithContentType.type,
+      optionsHeadersWithContentType
+    );
+    assert.deepEqual(
+      options.headers,
+      {
+        'Content-Type': 'application/special-type',
+        'custom-header': 'foo',
+      },
+      "POST call's options has the original content-type header"
+    );
+  });
+
   test('parseFetchResponseForError is able to be overwritten to mutate the error payload that gets passed along', function(assert) {
     assert.expect(1);
 

--- a/tests/unit/utils/mung-options-for-fetch-test.js
+++ b/tests/unit/utils/mung-options-for-fetch-test.js
@@ -53,111 +53,12 @@ module('Unit | mungOptionsForFetch', function() {
         url: 'https://emberjs.com',
         method: 'POST',
         type: 'POST',
-        headers: {
-          'Content-Type': 'application/json; charset=utf-8'
-        },
         body: '{"a":1}',
         data: {
           a: 1
         }
       },
       "POST call's options are correct"
-    );
-  });
-
-  test('mungOptionsForFetch adds a default "Content-Type" header if none is present', function(assert) {
-    assert.expect(2);
-    const optionsNoHeaders = {
-      url: 'https://emberjs.com',
-      type: 'POST',
-      data: { a: 1 }
-    };
-    const optionsHeadersWithoutContentType = {
-      url: 'https://emberjs.com',
-      type: 'POST',
-      headers: {
-        'X-foo': 'bar'
-      },
-      data: { a: 1 }
-    };
-    let options = mungOptionsForFetch(optionsNoHeaders);
-    assert.deepEqual(
-      options.headers,
-      {
-        'Content-Type': 'application/json; charset=utf-8'
-      },
-      "POST call's options without a headers object now has a headers object which has a content-type header"
-    );
-
-    options = mungOptionsForFetch(optionsHeadersWithoutContentType);
-    assert.deepEqual(
-      options.headers,
-      {
-        'Content-Type': 'application/json; charset=utf-8',
-        'X-foo': 'bar'
-      },
-      "POST call's options with a headers object now has a content-type header"
-    );
-  });
-
-  test('mungOptionsForFetch does not add a "Content-Type" header if it is a GET request', function(assert) {
-    assert.expect(1);
-    const getOptions = {
-      url: 'https://emberjs.com',
-      type: 'GET',
-      headers: {
-        foo: 'bar'
-      }
-    };
-
-    let options = mungOptionsForFetch(getOptions);
-    assert.deepEqual(
-      options.headers,
-      {
-        foo: 'bar'
-      },
-      "GET call's options has no added content-type header"
-    );
-  });
-
-  test('mungOptionsForFetch does not add a "Content-Type" header if a POST request has no body', function(assert) {
-    assert.expect(1);
-    const PostNoDataOptions = {
-      url: 'https://emberjs.com',
-      type: 'GET',
-      headers: {
-        foo: 'bar'
-      }
-    };
-
-    let options = mungOptionsForFetch(PostNoDataOptions);
-    assert.deepEqual(
-      options.headers,
-      {
-        foo: 'bar'
-      },
-      'POST call with no body has no added content-type header'
-    );
-  });
-
-  test('mungOptionsForFetch respects the "Content-Type" header if present', function(assert) {
-    assert.expect(1);
-    const optionsHeadersWithContentType = {
-      url: 'https://emberjs.com',
-      type: 'POST',
-      headers: {
-        'Content-Type': 'application/special-type'
-      },
-      data: { a: 1 }
-    };
-
-    let options = mungOptionsForFetch(optionsHeadersWithContentType);
-    assert.deepEqual(
-      options.headers,
-      {
-        'Content-Type': 'application/special-type'
-      },
-      "POST call's options has the original content-type header"
     );
   });
 


### PR DESCRIPTION
Came across some code I should have moved in 9917ba094ed94cb419144c690d5f4c1ea7216c59. 

Currently, every request that doesn't have a content-type header set is being set to `application/json` (to mimic logic in ED's adapter). This breaks the incoming logic from #174 where the browser needs to set the content-type header correctly for FormData.