### PR TITLE
Upgrade abortcontroller-polyfill for webkit-based browsers fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "abortcontroller-polyfill": "^1.1.9",
+    "abortcontroller-polyfill": "^1.2.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.5",
     "broccoli-merge-trees": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,6 +673,11 @@ abortcontroller-polyfill@^1.1.9:
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.1.9.tgz#9fefe359fda2e9e0932dc85e6106453ac393b2da"
   integrity sha512-omvG7zOHIs3BphdH62Kh3xy8nlftAsTyp7PDa9EmC3Jz9pa6sZFYk7UhNgu9Y4sIBhj6jF0RgeFZYvPnsP5sBw==
 
+abortcontroller-polyfill@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.2.1.tgz#4e88847513a4ed691d5e4899d8b3a3af6f7d90ee"
+  integrity sha512-9jN7+BijYKWO8fxfcG7QZh7js6V+g3OjkxMRHfKWNjjs85048VY4cd27Uoe6yk55P66L/z7Dflu5+YEApgMzkA==
+
 accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"


### PR DESCRIPTION
closes https://github.com/ember-cli/ember-fetch/pull/179