### PR TITLE
handle stringifying data that was created with Object.create(null)

### DIFF
--- a/addon/utils/mung-options-for-fetch.js
+++ b/addon/utils/mung-options-for-fetch.js
@@ -26,9 +26,10 @@ export default function mungOptionsForFetch(_options) {
     } else {
       // NOTE: a request's body cannot be a POJO, so we stringify it if it is.
       // JSON.stringify removes keys with values of `undefined` (mimics jQuery.ajax).
+      // If the data has no constructor we assume it is a POJO created with Object.create(null).
       // If the data is not a POJO (it's a String, FormData, etc), we just set it.
       // If the data is a string, we assume it's a stringified object.
-      if (options.data.constructor === Object) {
+      if (!options.data.constructor || options.data.constructor === Object) {
         options.body = JSON.stringify(options.data);
       } else {
         options.body = options.data;

--- a/addon/utils/mung-options-for-fetch.js
+++ b/addon/utils/mung-options-for-fetch.js
@@ -26,10 +26,9 @@ export default function mungOptionsForFetch(_options) {
     } else {
       // NOTE: a request's body cannot be a POJO, so we stringify it if it is.
       // JSON.stringify removes keys with values of `undefined` (mimics jQuery.ajax).
-      // If the data has no constructor we assume it is a POJO created with Object.create(null).
       // If the data is not a POJO (it's a String, FormData, etc), we just set it.
       // If the data is a string, we assume it's a stringified object.
-      if (!options.data.constructor || options.data.constructor === Object) {
+      if (Object.prototype.toString.call(options.data) === "[object Object]") {
         options.body = JSON.stringify(options.data);
       } else {
         options.body = options.data;

--- a/tests/unit/utils/mung-options-for-fetch-test.js
+++ b/tests/unit/utils/mung-options-for-fetch-test.js
@@ -274,4 +274,19 @@ module('Unit | mungOptionsForFetch', function() {
     const postOptions = mungOptionsForFetch(postData);
     assert.equal(postOptions.body, formData, "'options.body' is the FormData passed in");
   });
+
+  test("mungOptionsForFetch sets the request body correctly when 'data' has no constructor", function(assert) {
+    assert.expect(1);
+
+    const data = Object.create(null);
+    data.request = "body";
+    const postData = {
+      url: 'https://emberjs.com',
+      type: 'POST',
+      data: data,
+    };
+
+    const postOptions = mungOptionsForFetch(postData);
+    assert.equal(postOptions.body, JSON.stringify(data), "'options.body' is properly converted to a string");
+  });
 });


### PR DESCRIPTION
The new Object detection in 6.3.0 for checking when to stringify data does not work for objects that don't have a prototype. I didn't think this would be a common case, but it turns out we ran into it when using Ember's `hash` helper - I reconstructed the issue in this twiddle:

https://ember-twiddle.com/865249c0847b7465f53f0d025bab95aa?openFiles=templates.application.hbs%2C