### PR TITLE
Update cacheKeyForTree to cache the treeForVendor

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const concat = require('broccoli-concat');
 const map = stew.map;
 const Rollup = require('broccoli-rollup');
 const BroccoliDebug = require('broccoli-debug');
+const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 
 const debug = BroccoliDebug.buildDebugCallback('ember-fetch');
 
@@ -135,11 +136,11 @@ module.exports = {
 
   cacheKeyForTree(treeType) {
     if (treeType === 'public') {
-      return require('calculate-cache-key-for-tree')('public', this, [!this.parent.parent]);
+      return calculateCacheKeyForTree('public', this, [!this.parent.parent]);
     } else {
       // make sure results of other treeFor* methods won't get opt-out of cache
       // including the "treeForVendor"
-      return require('calculate-cache-key-for-tree')(treeType, this);
+      return calculateCacheKeyForTree(treeType, this);
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -137,7 +137,9 @@ module.exports = {
     if (treeType === 'public') {
       return require('calculate-cache-key-for-tree')('public', this, [!this.parent.parent]);
     } else {
-      return this._super.cacheKeyForTree.call(this, treeType);
+      // make sure results of other treeFor* methods won't get opt-out of cache
+      // including the "treeForVendor"
+      return require('calculate-cache-key-for-tree')(treeType, this);
     }
   },
 


### PR DESCRIPTION
If an ember addon has a modified/overrided treeFor* method, the result of this treeFor method won't get cached, according to https://github.com/ember-cli/ember-cli/blob/master/lib/models/addon.js#L728. The `cacheKeyForTree('vendor')` will always return `null`, so if "ember-fetch" was depended by the app and other addons(e.g ember-data), it will recalculate the "treeForVendor" every time.
This PR make sure that the result of "treeForVendor" will be cached.