### PR TITLE
Add fetch response and error utils

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,13 @@ module.exports = {
   env: {
     browser: true
   },
+  globals: {
+    fetch: 'off',
+    Headers: 'off',
+    Request: 'off',
+    Response: 'off',
+    AbortController: 'off',
+  },
   rules: {
     'no-console': ["error", { allow: ['warn'] }]
   },

--- a/README.md
+++ b/README.md
@@ -115,6 +115,51 @@ If all your [browser targets](https://guides.emberjs.com/release/configuring-emb
 
 The way you do import remains same.
 
+### Error Handling
+
+`ember-fetch` comes with utility functions for matching responses and their response status codes.
+These utilities are to assist when transitioning from [`ember-ajax`](https://github.com/ember-cli/ember-ajax#error-handling)
+These include
+
+  - `isBadRequestResponse` (400)
+  - `isUnauthorizedResponse` (401)
+  - `isForbiddenResponse` (403)
+  - `isNotFoundResponse` (404)
+  - `isConflictResponse` (409)
+  - `isGoneResponse` (410)
+  - `isInvalidResponse` (422)
+  - `isServerErrorResponse` (5XX)
+  - `isSuccessResponse`
+
+And for aborted requests
+
+  - `isAbortError`
+
+
+```js
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+import {
+  isUnauthorizedResponse
+} from 'ember-fetch/errors';
+
+export default Route.extend({
+  model: function() {
+    const response = await fetch('/omg.json');
+    
+    if (response.ok) {
+      return response.json();
+    }
+    
+    if (isUnauthorizedResponse(response)) {
+      // handle 401 response
+      return;
+    }
+  }
+});
+
+```
+
 ## Browser Support
 
 * evergreen / IE10+ / Safari 6.1+ https://github.com/github/fetch#browser-support

--- a/README.md
+++ b/README.md
@@ -144,27 +144,25 @@ import {
 } from 'ember-fetch/errors';
 
 export default Route.extend({
-  model: function() {
-    try {
-      const response = await fetch('/omg.json');
-      
-      if (response.ok) {
-        return response.json();
-      } else if (isUnauthorizedResponse(response)) {
-        // handle 401 response
-      } else if (isServerErrorResponse(response)) {
-        // handle 5xx respones
-      }
-    } catch (e) {
-      if (isAbortError(error)) {
-        // handle aborted network error
-      }
-      // handle network error
-    }
-
+  model() {
+    return fetch('/omg.json')
+      .then(function(response) {
+        if (response.ok) {
+          return response.json();
+        } else if (isUnauthorizedResponse(response)) {
+          // handle 401 response
+        } else if (isServerErrorResponse(response)) {
+          // handle 5xx respones
+        }
+      })
+      .catch(function(error) {
+        if (isAbortError(error)) {
+          // handle aborted network error
+        }
+        // handle network error
+      });
   }
 });
-
 ```
 
 ## Browser Support

--- a/addon/errors.ts
+++ b/addon/errors.ts
@@ -1,0 +1,113 @@
+/**
+ * Checks if the given response is a FetchError
+ */
+export function isFetchError(response: Response): boolean {
+  return response.ok === false
+}
+
+/**
+ * Checks if the given response represents an unauthorized request error
+ */
+export function isUnauthorizedError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status === 401;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given response represents a forbidden request error
+ */
+export function isForbiddenError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status === 403;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given response represents an invalid request error
+ */
+export function isInvalidError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status === 422;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given response represents a bad request error
+ */
+export function isBadRequestError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status === 400;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given response represents a "not found" error
+ */
+export function isNotFoundError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status === 404;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given response represents a "gone" error
+ */
+export function isGoneError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status === 410;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given response represents an "abort" error
+ */
+export function isAbortError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status === 0;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given response represents a conflict error
+ */
+export function isConflictError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status === 409;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given response represents a server error
+ */
+export function isServerError(response: Response): boolean {
+  if (isFetchError(response)) {
+    return response.status >= 500 && response.status < 600;
+  }
+
+  return false
+}
+
+/**
+ * Checks if the given status code represents a successful request
+ */
+export function isSuccess(response: Response): boolean {
+  const s = response.status
+  return (s >= 200 && s < 300) || s === 304;
+}

--- a/addon/errors.ts
+++ b/addon/errors.ts
@@ -60,11 +60,3 @@ export function isConflictResponse(response: Response): boolean {
 export function isServerErrorResponse(response: Response): boolean {
   return response.status >= 500 && response.status < 600;
 }
-
-/**
- * Checks if the given status code represents a successful request
- */
-export function isSuccessResponse(response: Response): boolean {
-  const {status, ok} = response;
-  return ok && (status >= 200 && status < 300);
-}

--- a/addon/errors.ts
+++ b/addon/errors.ts
@@ -1,113 +1,70 @@
 /**
- * Checks if the given response is a FetchError
- */
-export function isFetchError(response: Response): boolean {
-  return response.ok === false
-}
-
-/**
  * Checks if the given response represents an unauthorized request error
  */
-export function isUnauthorizedError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status === 401;
-  }
-
-  return false
+export function isUnauthorizedResponse(response: Response): boolean {
+  return response.status === 401;
 }
 
 /**
  * Checks if the given response represents a forbidden request error
  */
-export function isForbiddenError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status === 403;
-  }
-
-  return false
+export function isForbiddenResponse(response: Response): boolean {
+  return response.status === 403;
 }
 
 /**
  * Checks if the given response represents an invalid request error
  */
-export function isInvalidError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status === 422;
-  }
-
-  return false
+export function isInvalidResponse(response: Response): boolean {
+  return response.status === 422;
 }
 
 /**
  * Checks if the given response represents a bad request error
  */
-export function isBadRequestError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status === 400;
-  }
-
-  return false
+export function isBadRequestResponse(response: Response): boolean {
+  return response.status === 400;
 }
 
 /**
  * Checks if the given response represents a "not found" error
  */
-export function isNotFoundError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status === 404;
-  }
-
-  return false
+export function isNotFoundResponse(response: Response): boolean {
+  return response.status === 404;
 }
 
 /**
  * Checks if the given response represents a "gone" error
  */
-export function isGoneError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status === 410;
-  }
-
-  return false
+export function isGoneResponse(response: Response): boolean {
+  return response.status === 410;
 }
 
 /**
- * Checks if the given response represents an "abort" error
+ * Checks if the given error is an "abort" error
  */
-export function isAbortError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status === 0;
-  }
-
-  return false
+export function isAbortError(error: DOMException): boolean {
+  return error.name == 'AbortError';
 }
 
 /**
  * Checks if the given response represents a conflict error
  */
-export function isConflictError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status === 409;
-  }
-
-  return false
+export function isConflictResponse(response: Response): boolean {
+  return response.status === 409;
 }
 
 /**
  * Checks if the given response represents a server error
  */
-export function isServerError(response: Response): boolean {
-  if (isFetchError(response)) {
-    return response.status >= 500 && response.status < 600;
-  }
-
-  return false
+export function isServerErrorResponse(response: Response): boolean {
+  return response.status >= 500 && response.status < 600;
 }
 
 /**
  * Checks if the given status code represents a successful request
  */
-export function isSuccess(response: Response): boolean {
-  const s = response.status
-  return (s >= 200 && s < 300) || s === 304;
+export function isSuccessResponse(response: Response): boolean {
+  const {status, ok} = response;
+  return ok && (status >= 200 && status < 300);
 }

--- a/tests/acceptance/error-test.js
+++ b/tests/acceptance/error-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import Pretender from 'pretender';
-import fetch, {AbortController} from 'fetch';
+import fetch, { AbortController } from 'fetch';
 import {
   isUnauthorizedResponse,
   isForbiddenResponse,
@@ -9,7 +9,6 @@ import {
   isInvalidResponse,
   isBadRequestResponse,
   isServerErrorResponse,
-  isSuccessResponse,
   isAbortError,
   isConflictResponse
 } from 'ember-fetch/errors';
@@ -23,20 +22,6 @@ module('Acceptance: Errors', function(hooks) {
 
   hooks.afterEach(function() {
     server.shutdown();
-  });
-
-  test('isSuccessResponse', async function(assert) {
-    server.get('/success', function() {
-      return [
-        200,
-        { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'success' })
-      ];
-    });
-
-    const response = await fetch('/success')
-
-    assert.ok(isSuccessResponse(response))
   });
 
   test('isInvalidResponse', async function(assert) {

--- a/tests/acceptance/error-test.js
+++ b/tests/acceptance/error-test.js
@@ -1,19 +1,17 @@
 import { module, test } from 'qunit';
 import Pretender from 'pretender';
-import { later } from '@ember/runloop'
 import fetch, {AbortController} from 'fetch';
 import {
-  isFetchError,
-  isUnauthorizedError,
-  isForbiddenError,
-  isNotFoundError,
-  isGoneError,
-  isInvalidError,
-  isBadRequestError,
-  isServerError,
-  isSuccess,
+  isUnauthorizedResponse,
+  isForbiddenResponse,
+  isNotFoundResponse,
+  isGoneResponse,
+  isInvalidResponse,
+  isBadRequestResponse,
+  isServerErrorResponse,
+  isSuccessResponse,
   isAbortError,
-  isConflictError
+  isConflictResponse
 } from 'ember-fetch/errors';
 
 module('Acceptance: Errors', function(hooks) {
@@ -27,7 +25,7 @@ module('Acceptance: Errors', function(hooks) {
     server.shutdown();
   });
 
-  test('isSuccess', async function(assert) {
+  test('isSuccessResponse', async function(assert) {
     server.get('/success', function() {
       return [
         200,
@@ -38,119 +36,105 @@ module('Acceptance: Errors', function(hooks) {
 
     const response = await fetch('/success')
 
-    assert.ok(isSuccess(response))
+    assert.ok(isSuccessResponse(response))
   });
 
-  test('isFetchError', async function(assert) {
-    server.get('/fetch-error', function() {
-      return [
-        999,
-        { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'fetch-error' })
-      ];
-    });
-
-    const response = await fetch('/fetch-error')
-
-    assert.ok(isFetchError(response))
-  });
-
-  test('isInvalidError', async function(assert) {
-    server.get('/invalid-error', function() {
+  test('isInvalidResponse', async function(assert) {
+    server.get('/invalid-response', function() {
       return [
         422,
         { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'invalid-error' })
+        JSON.stringify({ name: 'invalid-response' })
       ];
     });
 
-    const response = await fetch('/invalid-error')
+    const response = await fetch('/invalid-response')
 
-    assert.ok(isInvalidError(response))
+    assert.ok(isInvalidResponse(response))
   });
 
-  test('isUnauthorizedError', async function(assert) {
-    server.get('/unauthorized-error', function() {
+  test('isUnauthorizedResponse', async function(assert) {
+    server.get('/unauthorized-response', function() {
       return [
         401,
         { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'unauthorized-error' })
+        JSON.stringify({ name: 'unauthorized-response' })
       ];
     });
 
-    const response = await fetch('/unauthorized-error')
+    const response = await fetch('/unauthorized-response')
 
-    assert.ok(isUnauthorizedError(response))
+    assert.ok(isUnauthorizedResponse(response))
   });
 
-  test('isForbiddenError', async function(assert) {
-    server.get('/forbidden-error', function() {
+  test('isForbiddenResponse', async function(assert) {
+    server.get('/forbidden-response', function() {
       return [
         403,
         { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'forbidden-error' })
+        JSON.stringify({ name: 'forbidden-response' })
       ];
     });
 
-    const response = await fetch('/forbidden-error')
+    const response = await fetch('/forbidden-response')
 
-    assert.ok(isForbiddenError(response))
+    assert.ok(isForbiddenResponse(response))
   });
 
-  test('isNotFoundError', async function(assert) {
-    server.get('/not-found-error', function() {
+  test('isNotFoundResponse', async function(assert) {
+    server.get('/not-found-response', function() {
       return [
         404,
         { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'not-found-error' })
+        JSON.stringify({ name: 'not-found-response' })
       ];
     });
 
-    const response = await fetch('/not-found-error')
+    const response = await fetch('/not-found-response')
 
-    assert.ok(isNotFoundError(response))
+    assert.ok(isNotFoundResponse(response))
   });
 
-  test('isGoneError', async function(assert) {
-    server.get('/gone-error', function() {
+  test('isGoneResponse', async function(assert) {
+    server.get('/gone-response', function() {
       return [
         410,
         { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'gone-error' })
+        JSON.stringify({ name: 'gone-response' })
       ];
     });
 
-    const response = await fetch('/gone-error')
+    const response = await fetch('/gone-response')
 
-    assert.ok(isGoneError(response))
+    assert.ok(isGoneResponse(response))
   });
 
-  test('isBadRequestError', async function(assert) {
-    server.get('/bad-request-error', function() {
+  test('isBadRequestResponse', async function(assert) {
+    server.get('/bad-request-response', function() {
       return [
         400,
         { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'bad-request-error' })
+        JSON.stringify({ name: 'bad-request-response' })
       ];
     });
 
-    const response = await fetch('/bad-request-error')
+    const response = await fetch('/bad-request-response')
 
-    assert.ok(isBadRequestError(response))
+    assert.ok(isBadRequestResponse(response))
   });
 
-  test('isServerError', async function(assert) {
-    server.get('/server-error', function() {
+  test('isServerErrorResponse', async function(assert) {
+    server.get('/server-error-response', function() {
       return [
         555,
         { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'server-error' })
+        JSON.stringify({ name: 'server-error-response' })
       ];
     });
 
-    const response = await fetch('/server-error')
+    const response = await fetch('/server-error-response')
 
-    assert.ok(isServerError(response))
+    assert.ok(isServerErrorResponse(response))
   });
 
   test('isAbortError', async function(assert) {
@@ -165,24 +149,24 @@ module('Acceptance: Errors', function(hooks) {
     const controller = new AbortController();
     const signal = controller.signal;
 
-    later(controller, 'abort', 500);
+    controller.abort()
 
-    const response = await fetch('/abort-error', {signal})
-
-    assert.ok(isAbortError(response))
+    assert.rejects(fetch('/abort-error', {signal}), function (error) {
+      return isAbortError(error)
+    })
   });
 
-  test('isConflictError', async function(assert) {
-    server.get('/conflict-error', function() {
+  test('isConflictResponse', async function(assert) {
+    server.get('/conflict-response', function() {
       return [
         409,
         { 'Content-Type': 'text/json'},
-        JSON.stringify({ name: 'conflict-error' })
+        JSON.stringify({ name: 'conflict-response' })
       ];
     });
 
-    const response = await fetch('/conflict-error')
+    const response = await fetch('/conflict-response')
 
-    assert.ok(isConflictError(response))
+    assert.ok(isConflictResponse(response))
   });
 });

--- a/tests/acceptance/error-test.js
+++ b/tests/acceptance/error-test.js
@@ -1,0 +1,188 @@
+import { module, test } from 'qunit';
+import Pretender from 'pretender';
+import { later } from '@ember/runloop'
+import fetch, {AbortController} from 'fetch';
+import {
+  isFetchError,
+  isUnauthorizedError,
+  isForbiddenError,
+  isNotFoundError,
+  isGoneError,
+  isInvalidError,
+  isBadRequestError,
+  isServerError,
+  isSuccess,
+  isAbortError,
+  isConflictError
+} from 'ember-fetch/errors';
+
+module('Acceptance: Errors', function(hooks) {
+  var server;
+
+  hooks.beforeEach(function() {
+    server = new Pretender();
+  });
+
+  hooks.afterEach(function() {
+    server.shutdown();
+  });
+
+  test('isSuccess', async function(assert) {
+    server.get('/success', function() {
+      return [
+        200,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'success' })
+      ];
+    });
+
+    const response = await fetch('/success')
+
+    assert.ok(isSuccess(response))
+  });
+
+  test('isFetchError', async function(assert) {
+    server.get('/fetch-error', function() {
+      return [
+        999,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'fetch-error' })
+      ];
+    });
+
+    const response = await fetch('/fetch-error')
+
+    assert.ok(isFetchError(response))
+  });
+
+  test('isInvalidError', async function(assert) {
+    server.get('/invalid-error', function() {
+      return [
+        422,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'invalid-error' })
+      ];
+    });
+
+    const response = await fetch('/invalid-error')
+
+    assert.ok(isInvalidError(response))
+  });
+
+  test('isUnauthorizedError', async function(assert) {
+    server.get('/unauthorized-error', function() {
+      return [
+        401,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'unauthorized-error' })
+      ];
+    });
+
+    const response = await fetch('/unauthorized-error')
+
+    assert.ok(isUnauthorizedError(response))
+  });
+
+  test('isForbiddenError', async function(assert) {
+    server.get('/forbidden-error', function() {
+      return [
+        403,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'forbidden-error' })
+      ];
+    });
+
+    const response = await fetch('/forbidden-error')
+
+    assert.ok(isForbiddenError(response))
+  });
+
+  test('isNotFoundError', async function(assert) {
+    server.get('/not-found-error', function() {
+      return [
+        404,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'not-found-error' })
+      ];
+    });
+
+    const response = await fetch('/not-found-error')
+
+    assert.ok(isNotFoundError(response))
+  });
+
+  test('isGoneError', async function(assert) {
+    server.get('/gone-error', function() {
+      return [
+        410,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'gone-error' })
+      ];
+    });
+
+    const response = await fetch('/gone-error')
+
+    assert.ok(isGoneError(response))
+  });
+
+  test('isBadRequestError', async function(assert) {
+    server.get('/bad-request-error', function() {
+      return [
+        400,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'bad-request-error' })
+      ];
+    });
+
+    const response = await fetch('/bad-request-error')
+
+    assert.ok(isBadRequestError(response))
+  });
+
+  test('isServerError', async function(assert) {
+    server.get('/server-error', function() {
+      return [
+        555,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'server-error' })
+      ];
+    });
+
+    const response = await fetch('/server-error')
+
+    assert.ok(isServerError(response))
+  });
+
+  test('isAbortError', async function(assert) {
+    server.get('/abort-error', function() {
+      return [
+        200,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'abort-error' })
+      ];
+    }, 2000);
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    later(controller, 'abort', 500);
+
+    const response = await fetch('/abort-error', {signal})
+
+    assert.ok(isAbortError(response))
+  });
+
+  test('isConflictError', async function(assert) {
+    server.get('/conflict-error', function() {
+      return [
+        409,
+        { 'Content-Type': 'text/json'},
+        JSON.stringify({ name: 'conflict-error' })
+      ];
+    });
+
+    const response = await fetch('/conflict-error')
+
+    assert.ok(isConflictError(response))
+  });
+});

--- a/tests/unit/error-test.js
+++ b/tests/unit/error-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import {Response} from 'fetch';
+import { Response } from 'fetch';
 
 import {
   isUnauthorizedResponse,
@@ -9,7 +9,6 @@ import {
   isInvalidResponse,
   isBadRequestResponse,
   isServerErrorResponse,
-  isSuccessResponse,
   isAbortError,
   isConflictResponse
 } from 'ember-fetch/errors';
@@ -53,13 +52,5 @@ module('Errors', function() {
 
   test('isConflictResponse', function(assert) {
     assert.ok(isConflictResponse(new Response(null, { status: 409 })));
-  });
-
-  test('isSuccessResponse', function(assert) {
-    assert.ok(isSuccessResponse(new Response(null, { status: 200 })));
-    assert.ok(isSuccessResponse(new Response(null, { status: 299 })));
-    assert.notOk(isSuccessResponse(new Response(null, { status: 300 })));
-    assert.notOk(isSuccessResponse(new Response(null, { status: 400 })));
-    assert.notOk(isSuccessResponse(new Response(null, { status: 500 })));
   });
 });

--- a/tests/unit/error-test.js
+++ b/tests/unit/error-test.js
@@ -1,74 +1,65 @@
 import { module, test } from 'qunit';
+import {Response} from 'fetch';
 
 import {
-  isFetchError,
-  isUnauthorizedError,
-  isForbiddenError,
-  isNotFoundError,
-  isGoneError,
-  isInvalidError,
-  isBadRequestError,
-  isServerError,
-  isSuccess,
+  isUnauthorizedResponse,
+  isForbiddenResponse,
+  isNotFoundResponse,
+  isGoneResponse,
+  isInvalidResponse,
+  isBadRequestResponse,
+  isServerErrorResponse,
+  isSuccessResponse,
   isAbortError,
-  isConflictError
+  isConflictResponse
 } from 'ember-fetch/errors';
 
 module('Errors', function() {
-  test('isUnauthorizedError', function(assert) {
-    assert.ok(isUnauthorizedError({ ok: false, status: 401 }));
+  test('isUnauthorizedResponse', function(assert) {
+    assert.ok(isUnauthorizedResponse(new Response(null, { status: 401 })));
   });
 
-  test('isForbiddenError', function(assert) {
-    assert.ok(isForbiddenError({ ok: false, status: 403 }));
+  test('isForbiddenResponse', function(assert) {
+    assert.ok(isForbiddenResponse(new Response(null, { status: 403 })));
   });
 
-  test('isNotFoundError', function(assert) {
-    assert.ok(isNotFoundError({ ok: false, status: 404 }));
-    assert.notOk(isNotFoundError({ ok: false, status: 400 }));
+  test('isNotFoundResponse', function(assert) {
+    assert.ok(isNotFoundResponse(new Response(null, { status: 404 })));
+    assert.notOk(isNotFoundResponse(new Response(null, { status: 400 })));
   });
 
-  test('isGoneError', function(assert) {
-    assert.ok(isGoneError({ ok: false, status: 410 }));
-    assert.notOk(isGoneError({ ok: false, status: 400 }));
+  test('isGoneResponse', function(assert) {
+    assert.ok(isGoneResponse(new Response(null, { status: 410 })));
+    assert.notOk(isGoneResponse(new Response(null, { status: 400 })));
   });
 
-  test('isInvalidError', function(assert) {
-    assert.ok(isInvalidError({ ok: false, status: 422 }));
+  test('isInvalidResponse', function(assert) {
+    assert.ok(isInvalidResponse(new Response(null, { status: 422 })));
   });
 
-  test('isBadRequestError', function(assert) {
-    assert.ok(isBadRequestError({ ok: false, status: 400 }));
+  test('isBadRequestResponse', function(assert) {
+    assert.ok(isBadRequestResponse(new Response(null, { status: 400 })));
   });
 
-  test('isServerError', function(assert) {
-    assert.notOk(isServerError({ ok: false, status: 499 }));
-    assert.ok(isServerError({ ok: false, status: 500 }));
-    assert.ok(isServerError({ ok: false, status: 599 }));
-    assert.notOk(isServerError({ ok: false, status: 600 }));
-  });
-
-  test('isFetchError', function(assert) {
-    assert.ok(isFetchError({ ok: false }));
-    assert.notOk(isFetchError({ ok: true }));
+  test('isServerErrorResponse', function(assert) {
+    assert.notOk(isServerErrorResponse(new Response(null, { status: 499 })));
+    assert.ok(isServerErrorResponse(new Response(null, { status: 500 })));
+    assert.ok(isServerErrorResponse(new Response(null, { status: 599 })));
   });
 
   test('isAbortError', function(assert) {
-    assert.ok(isAbortError({ ok: false, status: 0 }));
+    assert.ok(isAbortError(new DOMException('AbortError', 'AbortError')));
   });
 
-  test('isConflictError', function(assert) {
-    assert.ok(isConflictError({ ok: false, status: 409 }));
+  test('isConflictResponse', function(assert) {
+    assert.ok(isConflictResponse(new Response(null, { status: 409 })));
   });
 
-  test('isSuccess', function(assert) {
-    assert.notOk(isSuccess({ ok: false, status: 100 }));
-    assert.notOk(isSuccess({ ok: false, status: 199 }));
-    assert.ok(isSuccess({ ok: false, status: 200 }));
-    assert.ok(isSuccess({ ok: false, status: 299 }));
-    assert.notOk(isSuccess({ ok: false, status: 300 }));
-    assert.ok(isSuccess({ ok: false, status: 304 }));
-    assert.notOk(isSuccess({ ok: false, status: 400 }));
-    assert.notOk(isSuccess({ ok: false, status: 500 }));
+  test('isSuccessResponse', function(assert) {
+    assert.ok(isSuccessResponse(new Response(null, { status: 200 })));
+    assert.ok(isSuccessResponse(new Response(null, { status: 299 })));
+    assert.notOk(isSuccessResponse(new Response(null, { status: 300 })));
+    assert.notOk(isSuccessResponse(new Response(null, { status: 400 })));
+    assert.notOk(isSuccessResponse(new Response(null, { status: 500 })));
   });
 });

--- a/tests/unit/error-test.js
+++ b/tests/unit/error-test.js
@@ -1,0 +1,74 @@
+import { module, test } from 'qunit';
+
+import {
+  isFetchError,
+  isUnauthorizedError,
+  isForbiddenError,
+  isNotFoundError,
+  isGoneError,
+  isInvalidError,
+  isBadRequestError,
+  isServerError,
+  isSuccess,
+  isAbortError,
+  isConflictError
+} from 'ember-fetch/errors';
+
+module('Errors', function() {
+  test('isUnauthorizedError', function(assert) {
+    assert.ok(isUnauthorizedError({ ok: false, status: 401 }));
+  });
+
+  test('isForbiddenError', function(assert) {
+    assert.ok(isForbiddenError({ ok: false, status: 403 }));
+  });
+
+  test('isNotFoundError', function(assert) {
+    assert.ok(isNotFoundError({ ok: false, status: 404 }));
+    assert.notOk(isNotFoundError({ ok: false, status: 400 }));
+  });
+
+  test('isGoneError', function(assert) {
+    assert.ok(isGoneError({ ok: false, status: 410 }));
+    assert.notOk(isGoneError({ ok: false, status: 400 }));
+  });
+
+  test('isInvalidError', function(assert) {
+    assert.ok(isInvalidError({ ok: false, status: 422 }));
+  });
+
+  test('isBadRequestError', function(assert) {
+    assert.ok(isBadRequestError({ ok: false, status: 400 }));
+  });
+
+  test('isServerError', function(assert) {
+    assert.notOk(isServerError({ ok: false, status: 499 }));
+    assert.ok(isServerError({ ok: false, status: 500 }));
+    assert.ok(isServerError({ ok: false, status: 599 }));
+    assert.notOk(isServerError({ ok: false, status: 600 }));
+  });
+
+  test('isFetchError', function(assert) {
+    assert.ok(isFetchError({ ok: false }));
+    assert.notOk(isFetchError({ ok: true }));
+  });
+
+  test('isAbortError', function(assert) {
+    assert.ok(isAbortError({ ok: false, status: 0 }));
+  });
+
+  test('isConflictError', function(assert) {
+    assert.ok(isConflictError({ ok: false, status: 409 }));
+  });
+
+  test('isSuccess', function(assert) {
+    assert.notOk(isSuccess({ ok: false, status: 100 }));
+    assert.notOk(isSuccess({ ok: false, status: 199 }));
+    assert.ok(isSuccess({ ok: false, status: 200 }));
+    assert.ok(isSuccess({ ok: false, status: 299 }));
+    assert.notOk(isSuccess({ ok: false, status: 300 }));
+    assert.ok(isSuccess({ ok: false, status: 304 }));
+    assert.notOk(isSuccess({ ok: false, status: 400 }));
+    assert.notOk(isSuccess({ ok: false, status: 500 }));
+  });
+});

--- a/tests/unit/utils/determine-body-promise-test.js
+++ b/tests/unit/utils/determine-body-promise-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import {Response} from 'fetch';
 import determineBodyPromise from 'ember-fetch/utils/determine-body-promise';
 
 module('Unit | determineBodyPromise', function() {

--- a/tests/unit/utils/determine-body-promise-test.js
+++ b/tests/unit/utils/determine-body-promise-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import {Response} from 'fetch';
+import { Response } from 'fetch';
 import determineBodyPromise from 'ember-fetch/utils/determine-body-promise';
 
 module('Unit | determineBodyPromise', function() {


### PR DESCRIPTION
Transitioning from `ember-ajax` to `ember-fetch` and noticed there weren't any [error detection helpers](https://github.com/ember-cli/ember-ajax#error-detection-helpers)

This PR adds similar helpers, mostly a copy/paste. Main motivation is to aid in transitioning between the two.

```js
import {
  isNotFoundResponse,
  isForbiddenResponse
} from 'ember-fetch/errors';
```

I looked through npm briefly to see if something similar already existed, but couldn't find anything. If we want to move forward with this, I can add some documentation to the readme.