### PR TITLE
Add support for specifying a custom serialization function for query parameters.

### DIFF
--- a/addon/mixins/adapter-fetch.ts
+++ b/addon/mixins/adapter-fetch.ts
@@ -1,12 +1,12 @@
 import Mixin from '@ember/object/mixin';
-import { assign } from '@ember/polyfills';
-import RSVP, { reject } from 'rsvp';
+import {assign} from '@ember/polyfills';
+import RSVP, {reject} from 'rsvp';
 import fetch from 'fetch';
 import mungOptionsForFetch from '../utils/mung-options-for-fetch';
 import determineBodyPromise from '../utils/determine-body-promise';
 import DS from 'ember-data';
 import Mix from '@ember/polyfills/types';
-import { get } from '@ember/object';
+import {get} from '@ember/object';
 import {
   PlainObject,
   PlainHeaders,
@@ -56,10 +56,12 @@ export interface FetchAdapter {
     requestData: object,
     error?: Error
   ): Error | object | DS.AdapterError;
+  serializeQueryParams?(queryParamsObject: object | string): string
 }
 
 export default Mixin.create<FetchAdapter, DS.RESTAdapter>({
   headers: undefined,
+  serializeQueryParams: undefined,
   /**
    * @override
    */
@@ -74,7 +76,7 @@ export default Mixin.create<FetchAdapter, DS.RESTAdapter>({
       hash.headers = assign(hash.headers || {}, adapterHeaders);
     }
 
-    const mungedOptions = mungOptionsForFetch(hash);
+    const mungedOptions = mungOptionsForFetch(hash, this.serializeQueryParams);
 
     // Mimics the default behavior in Ember Data's `ajaxOptions`, namely to set the
     // 'Content-Type' header to application/json if it is not a GET request and it has a body.
@@ -107,7 +109,7 @@ export default Mixin.create<FetchAdapter, DS.RESTAdapter>({
 
     return (
       this._ajaxRequest(hash)
-        // @ts-ignore
+      // @ts-ignore
         .catch((error, response, requestData) => {
           throw this.ajaxError(this, response, null, requestData, error);
         })
@@ -119,9 +121,9 @@ export default Mixin.create<FetchAdapter, DS.RESTAdapter>({
         })
         .then(
           ({
-            response,
-            payload
-          }: {
+             response,
+             payload
+           }: {
             response: Response;
             payload: string | object | undefined;
           }) => {

--- a/addon/utils/mung-options-for-fetch.ts
+++ b/addon/utils/mung-options-for-fetch.ts
@@ -28,7 +28,7 @@ export default function mungOptionsForFetch(
     if (hash.method === 'GET' || hash.method === 'HEAD') {
       // If no options are passed, Ember Data sets `data` to an empty object, which we test for.
       if (Object.keys(hash.data).length) {
-        // Test if there are already query params in the url (mimics jQuey.ajax).
+        // Test if there are already query params in the url (mimics jQuery.ajax).
         const queryParamDelimiter = hash.url.indexOf('?') > -1 ? '&' : '?';
         hash.url += `${queryParamDelimiter}${serializeQueryParams(hash.data)}`;
       }

--- a/addon/utils/mung-options-for-fetch.ts
+++ b/addon/utils/mung-options-for-fetch.ts
@@ -1,5 +1,5 @@
 import { assign } from '@ember/polyfills';
-import { serializeQueryParams } from './serialize-query-params';
+import { serializeQueryParams as defaultSerializeQueryParams } from './serialize-query-params';
 import {
   Method,
   FetchOptions,
@@ -11,8 +11,10 @@ import {
  * Helper function that translates the options passed to `jQuery.ajax` into a format that `fetch` expects.
  */
 export default function mungOptionsForFetch(
-  options: AjaxOptions
+  options: AjaxOptions,
+  serializeQueryParams?: (queryParamsObject: object | string) => string
 ): FetchOptions {
+  serializeQueryParams = serializeQueryParams || defaultSerializeQueryParams;
   const hash = assign(
     {
       credentials: 'same-origin'

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -266,4 +266,34 @@ module('Unit | Mixin | adapter-fetch', function(hooks) {
       }
     });
   });
+
+  test('an overridden serializeQueryParams function is correctly used', function(assert) {
+    const adapter = EmberObject.extend(AdapterFetchMixin, {
+      serializeQueryParams() {
+        return "custom=0"
+      }
+    }).create();
+
+    const options = {
+      url: 'https://emberjs.com',
+      type: 'GET',
+      data: { a: 1 }
+    };
+
+    let returnedOptions = adapter.ajaxOptions(options.url, options.type, options);
+    assert.equal(returnedOptions.url, `${options.url}?custom=0`);
+  });
+
+  test('a set serializeQueryParams function is correctly used', function(assert) {
+    this.basicAdapter.serializeQueryParams = () => "custom=0";
+
+    const options = {
+      url: 'https://emberjs.com',
+      type: 'GET',
+      data: { a: 1 }
+    };
+
+    let returnedOptions = this.basicAdapter.ajaxOptions(options.url, options.type, options);
+    assert.equal(returnedOptions.url, `${options.url}?custom=0`);
+  });
 });

--- a/tests/unit/utils/mung-options-for-fetch-test.js
+++ b/tests/unit/utils/mung-options-for-fetch-test.js
@@ -289,4 +289,16 @@ module('Unit | mungOptionsForFetch', function() {
     const postOptions = mungOptionsForFetch(postData);
     assert.equal(postOptions.body, JSON.stringify(data), "'options.body' is properly converted to a string");
   });
+
+  test("mungOptionsForFetch uses a custom serializeQueryParams function when it is specified",assert => {
+    const data = { paramName: [1,2,3]};
+    const postData = {
+      url: 'https://emberjs.com',
+      type: 'GET',
+      data
+    };
+
+    const postOptions = mungOptionsForFetch(postData, () => "custom=0");
+    assert.equal(postOptions.url, "https://emberjs.com?custom=0", "custom serializeQueryParams is used");
+  });
 });


### PR DESCRIPTION
It's currently not possible to change how data gets mapped to query parameters. This can be cumbersome when a server may be expecting 'traditional style' formatted query parameters, for example.

With this PR  a custom serialization function can be specified.