### PR TITLE
Enable absolute url transform for Request in FastBoot

### DIFF
--- a/public/fetch-fastboot.js
+++ b/public/fetch-fastboot.js
@@ -34,6 +34,18 @@ define('fetch', ['exports'], function(exports) {
 
   var FastbootHost, FastbootProtocol;
 
+  class FastBootRequest extends nodeFetch.Request {
+    constructor(input, init) {
+      if (typeof input === 'string') {
+        input = buildAbsoluteUrl(input, FastbootProtocol, FastbootHost);
+      } else if (input && input.href) {
+        // WHATWG URL or Node.js Url Object
+        input = buildAbsoluteUrl(input.href, FastbootProtocol, FastbootHost);
+      }
+      super(input, init);
+    }
+  }
+
   /**
    * Isomorphic `fetch` API for both browser and fastboot
    *
@@ -47,9 +59,9 @@ define('fetch', ['exports'], function(exports) {
    * @param {Object} [options]
    */
   exports.default = function fetch(input, options) {
-    if (typeof input === 'object') {
-      input.url = buildAbsoluteUrl(input.url, FastbootProtocol, FastbootHost);
-    } else {
+    if (input && input.href) {
+      input.url = buildAbsoluteUrl(input.href, FastbootProtocol, FastbootHost);
+    } else if (typeof input === 'string') {
       input = buildAbsoluteUrl(input, FastbootProtocol, FastbootHost);
     }
     return nodeFetch(input, options);
@@ -62,7 +74,7 @@ define('fetch', ['exports'], function(exports) {
     FastbootProtocol = protocol;
     FastbootHost = host;
   }
-  exports.Request = nodeFetch.Request;
+  exports.Request = FastBootRequest;
   exports.Headers = nodeFetch.Headers;
   exports.Response = nodeFetch.Response;
   exports.AbortController = AbortControllerPolyfill.AbortController;

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -55,6 +55,7 @@ describe('renders in fastboot build', function() {
       }
     }).then(function(response) {
       expect(response.body).to.contain('Hello World! fetch');
+      expect(response.body).to.contain('Hello World! fetch (Request)');
     });
   });
 });

--- a/test/fixtures/dummy/app/routes/index.js
+++ b/test/fixtures/dummy/app/routes/index.js
@@ -1,12 +1,15 @@
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
-import fetch from 'fetch';
+import fetch, { Request } from 'fetch';
 import ajax from 'ember-fetch/ajax';
 
 export default Route.extend({
   model: function() {
     return hash({
       fetch: fetch('/omg.json').then(function(request) {
+        return request.json();
+      }),
+      request: fetch(new Request('/omg.json')).then(function(request) {
         return request.json();
       }),
       ajax: ajax('/omg.json')

--- a/test/fixtures/dummy/app/templates/index.hbs
+++ b/test/fixtures/dummy/app/templates/index.hbs
@@ -2,6 +2,10 @@
   Hello {{model.fetch.name}}! fetch
 </div>
 
+<div class="fetch request">
+  Hello {{model.request.name}}! fetch (Request)
+</div>
+
 <div class="ajax">
   Hello {{model.ajax.name}}! ajax
 </div>


### PR DESCRIPTION
Overrides https://github.com/ember-cli/ember-fetch/pull/356, fixes https://github.com/ember-cli/ember-fetch/issues/355.
> The problem is that node-fetch parses input argument in Request's constructor, so any changes made after that are not taken into account, and the request fails with Only absolute URLs are supported error.
> Also, the url property is marked as read-only https://developer.mozilla.org/en-US/docs/Web/API/Request/url, so no changes should be made on that property.