### PR TITLE
Only show FetchAdapter deprecation for ember-data >= 3.9.2

### DIFF
--- a/addon/mixins/adapter-fetch.ts
+++ b/addon/mixins/adapter-fetch.ts
@@ -17,6 +17,7 @@ import {
   AjaxOptions
 } from 'ember-fetch/types';
 import { Fix } from '@ember/object/-private/types';
+import { lte } from 'ember-compatibility-helpers';
 
 /**
  * Helper function to create a plain object from the response's Headers.
@@ -65,7 +66,9 @@ export default Mixin.create<FetchAdapter, DS.RESTAdapter>({
 
   init() {
     this._super(...arguments);
-    deprecate('FetchAdapter is deprecated, it is no longer required for ember-data>=3.9.2', false, {
+    // TS currently fails on the `lte()` check due to https://github.com/pzuraq/ember-compatibility-helpers/issues/34
+    // @ts-ignore
+    deprecate('FetchAdapter is deprecated, it is no longer required for ember-data>=3.9.2', lte('ember-data', '3.9.1'), {
       id: 'deprecate-fetch-ember-data-support',
       until: '7.0.0'
     });

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "caniuse-api": "^3.0.0",
     "ember-cli-babel": "^7.10.0",
     "ember-cli-typescript": "^2.0.2",
+    "ember-compatibility-helpers": "^1.2.0",
     "node-fetch": "^2.6.0",
     "whatwg-fetch": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4202,7 +4202,7 @@ ember-cli@~3.9.0:
     watch-detector "^0.1.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.1:
+ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
   integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==


### PR DESCRIPTION
As described in #391 , the deprecation message for the FetchAdapter should only be shown if using Ember Data >=3.9.2.