### PR TITLE
Add section to the README for deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,33 @@ export default Route.extend({
 * we actually don't bundle github/fetch rather we merely wrap/transform what
   comes from `node_modules`, so we should be resilient to changes assuming
   semver from the fetch module
+  
+## Deprecations
+
+### deprecate-fetch-ember-data-support
+
+Starting with [`ember-data`](https://www.npmjs.com/package/ember-data) v3.9.2, the library comes with built-in fetch support.
+To address this deprecation, find imports and uses of the `ember-fetch/mixins/adapter-fetch` module:
+
+Before:
+
+```
+// app/adapters/application.js
+import DS from 'ember-data';
+import AdapterFetch from 'ember-fetch/mixins/adapter-fetch';
+
+export default DS.RESTAdapter.extend(AdapterFetch, {
+  …
+});
+```
+
+After:
+
+```
+// app/adapters/application.js
+import DS from 'ember-data';
+
+export default DS.RESTAdapter.extend({
+  …
+});
+```


### PR DESCRIPTION
I put it in the README to make it the easiest to find and because I wanted to get the suggestion down before I forgot, but I am completely open to alternative suggestions :)
I had to do some spelunking because the deprecation mentions `FetchAdapter` but the documentation names the default export as `AdapterFetch` to match the module name.