### PR TITLE
Ignore fastboot build output file if app unused/disable fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,10 @@ module.exports = {
 
   // Only include public/fetch-fastboot.js if top level addon
   treeForPublic() {
-    return !this.parent.parent ? this._super.treeForPublic.apply(this, arguments) : null;
+    const fastbootEnabled = process.env.FASTBOOT_DISABLED !== 'true' 
+      && !!this.project.findAddonByName('ember-cli-fastboot');
+    return !this.parent.parent && fastbootEnabled;
+      ? this._super.treeForPublic.apply(this, arguments) : null;
   },
 
   cacheKeyForTree(treeType) {

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ module.exports = {
 
   // Only include public/fetch-fastboot.js if top level addon
   treeForPublic() {
-    const fastbootEnabled = process.env.FASTBOOT_DISABLED !== 'true' 
+    const fastbootEnabled = process.env.FASTBOOT_DISABLED !== 'true'
       && !!this.project.findAddonByName('ember-cli-fastboot');
     return !this.parent.parent && fastbootEnabled
       ? this._super.treeForPublic.apply(this, arguments) : null;

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ module.exports = {
   treeForPublic() {
     const fastbootEnabled = process.env.FASTBOOT_DISABLED !== 'true' 
       && !!this.project.findAddonByName('ember-cli-fastboot');
-    return !this.parent.parent && fastbootEnabled;
+    return !this.parent.parent && fastbootEnabled
       ? this._super.treeForPublic.apply(this, arguments) : null;
   },
 

--- a/test/without-fastboot-build-test.js
+++ b/test/without-fastboot-build-test.js
@@ -1,0 +1,42 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('chai-fs'));
+
+const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+
+describe('it builds without ember-cli-fastboot', function() {
+  this.timeout(300000);
+
+  let app;
+
+  beforeEach(function() {
+    app = new AddonTestApp();
+
+    return app
+      .create('dummy', { skipNpm: true })
+      .then(app =>
+        app.editPackageJSON(pkg => {
+          delete pkg.devDependencies['ember-cli-fastboot'];
+        })
+      )
+      .then(() => app.run('npm', 'install'));
+  });
+
+  it('builds no exist dist/ember-fetch/fetch-fastboot.js', function() {
+    return app.runEmberCommand('build').then(function() {
+      expect(app.filePath('dist/index.html')).to.be.a.file();
+      expect(app.filePath('dist/ember-fetch')).to.not.be.a.path();
+    });
+  });
+
+  it('build with process.env.FASTBOOT_DISABLED', function() {
+    process.env.FASTBOOT_DISABLED = 'true';
+    return app.runEmberCommand('build').then(function() {
+        expect(app.filePath('dist/index.html')).to.be.a.file();
+        expect(app.filePath('dist/ember-fetch')).to.not.be.a.path();
+    }).finally(function() {
+      delete process.env.FASTBOOT_DISABLED;
+    });
+  });
+});

--- a/test/without-fastboot-build-test.js
+++ b/test/without-fastboot-build-test.js
@@ -12,33 +12,46 @@ describe('it builds without ember-cli-fastboot', function() {
 
   beforeEach(function() {
     app = new AddonTestApp();
-
-    return app
-      .create('dummy', { skipNpm: true })
-      .then(app =>
-        app.editPackageJSON(pkg => {
-          delete pkg.devDependencies['ember-cli-fastboot'];
-        })
-      )
-      .then(() => app.run('npm', 'install'));
   });
 
   it('builds no exist dist/ember-fetch/fetch-fastboot.js', function() {
-    return app.runEmberCommand('build').then(function() {
-      expect(app.filePath('dist/index.html')).to.be.a.file();
-      expect(app.filePath('dist/ember-fetch')).to.not.be.a.path();
-    });
+    return app
+      .create('dummy', { skipNpm: true })
+      .then((app) =>
+        app.editPackageJSON((pkg) => {
+          delete pkg.devDependencies['ember-cli-fastboot'];
+        })
+      )
+      .then(() => app.run('npm', 'install'))
+      .then(() => app.runEmberCommand('build'))
+      .then(function() {
+        expect(app.filePath('dist/index.html')).to.be.a.file();
+        expect(app.filePath('dist/ember-fetch')).to.not.be.a.path();
+      });
   });
 
   it('build with process.env.FASTBOOT_DISABLED', function() {
     process.env.FASTBOOT_DISABLED = 'true';
-    return app.runEmberCommand('build').then(function() {
+    return app
+      .create('dummy', { skipNpm: true })
+      .then((app) =>
+        app.editPackageJSON((pkg) => {
+          pkg.devDependencies['ember-cli-fastboot'] = '*';
+        })
+      )
+      .then(() => app.run('npm', 'install'))
+      .then(() => app.runEmberCommand('build'))
+      .then(function() {
         expect(app.filePath('dist/index.html')).to.be.a.file();
         expect(app.filePath('dist/ember-fetch')).to.not.be.a.path();
-    }).then(function() {
-      delete process.env.FASTBOOT_DISABLED;
-    }, function() {
-      delete process.env.FASTBOOT_DISABLED;
-    });
+      })
+      .then(
+        function() {
+          delete process.env.FASTBOOT_DISABLED;
+        },
+        function() {
+          delete process.env.FASTBOOT_DISABLED;
+        }
+      );
   });
 });

--- a/test/without-fastboot-build-test.js
+++ b/test/without-fastboot-build-test.js
@@ -35,7 +35,9 @@ describe('it builds without ember-cli-fastboot', function() {
     return app.runEmberCommand('build').then(function() {
         expect(app.filePath('dist/index.html')).to.be.a.file();
         expect(app.filePath('dist/ember-fetch')).to.not.be.a.path();
-    }).finally(function() {
+    }).then(function() {
+      delete process.env.FASTBOOT_DISABLED;
+    }, function() {
       delete process.env.FASTBOOT_DISABLED;
     });
   });


### PR DESCRIPTION
hi @xg-wang :
i am doing work on reducing assets files size for deploy.
there is no ember-cli-fastboot in my project , so can we remove fetch-fastboot file in outputTree ? . 
