### PR TITLE
Resolve FastBoot dependencies at compile time

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,9 +93,12 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "fastbootDependencies": [
-      "node-fetch",
-      "abortcontroller-polyfill",
-      "abortcontroller-polyfill/dist/cjs-ponyfill"
+      "buffer",
+      "http",
+      "https",
+      "stream",
+      "url",
+      "zlib"
     ]
   }
 }

--- a/public/fetch-fastboot.js
+++ b/public/fetch-fastboot.js
@@ -1,12 +1,10 @@
-/* globals define FastBoot */
+/* globals define requirejs */
 define('fetch', ['exports'], function(exports) {
   var httpRegex = /^https?:\/\//;
   var protocolRelativeRegex = /^\/\//;
 
-  var AbortControllerPolyfill = FastBoot.require(
-    'abortcontroller-polyfill/dist/cjs-ponyfill'
-  );
-  var nodeFetch = FastBoot.require('node-fetch');
+  var AbortControllerPolyfill = requirejs('node-abortcontroller');
+  var nodeFetch = requirejs('node-fetch')['default'];
 
   function parseRequest(request) {
     if (request === null) {


### PR DESCRIPTION
This change makes FastBoot dependencies required at compile time, hence no need to `cd dist && npm install` as before. It somehow aligns with `ember-auto-import`, when app imports modules from 3rd packages, then EAI bundles these modules at compile time. I assume that this will be improved with Embroider in the future.