### PR TITLE
Test ember-fetch against an embroider build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
+    - env: EMBER_TRY_SCENARIO=embroider-tests
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -76,6 +76,16 @@ module.exports = async function() {
             '@ember/jquery': '^0.5.1'
           }
         }
+      },
+      {
+        name: 'embroider-tests',
+        npm: {
+          devDependencies: {
+            '@embroider/core': '*',
+            '@embroider/webpack': '*',
+            '@embroider/compat': '*',
+          },
+        },
       }
     ]
   };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,6 +16,16 @@ module.exports = function(defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
+  if ('@embroider/webpack' in app.dependencies()) {
+    const { Webpack } = require('@embroider/webpack'); // eslint-disable-line
+    return require('@embroider/compat') // eslint-disable-line
+      .compatBuild(app, Webpack, {
+        staticAddonTestSupportTrees: true,
+        staticAddonTrees: true,
+        staticHelpers: true,
+        staticComponents: true,
+      });
+  }
 
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "calculate-cache-key-for-tree": "^2.0.0",
     "caniuse-api": "^3.0.0",
     "ember-cli-babel": "^7.19.0",
-    "ember-cli-typescript": "^3.1.3",
+    "ember-cli-typescript": "^4.0.0-rc.1",
     "node-fetch": "^2.6.0",
     "whatwg-fetch": "^3.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4844,6 +4844,22 @@ ember-cli-typescript@^3.1.3:
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
 
+ember-cli-typescript@^4.0.0-rc.1:
+  version "4.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.0.0-rc.1.tgz#b0def77bc617e9bc77876cf90a984637dd38f40b"
+  integrity sha512-C8o24nGPyv1EN3EFhrYZK9CGG8dQVgBU3gucl/GBEbdXTjmiKLSJtm65IZOZh3uU+G4EO9iTVGGsKkw+j2DX3A==
+  dependencies:
+    ansi-to-html "^0.6.6"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    execa "^4.0.0"
+    fs-extra "^9.0.1"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^7.3.2"
+    stagehand "^1.0.0"
+    walk-sync "^2.2.0"
+
 ember-cli-uglify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-uglify/-/ember-cli-uglify-3.0.0.tgz#8819665b2cc5fe70e3ba9fe7a94645209bc42fd6"
@@ -11152,7 +11168,7 @@ walk-sync@^1.0.0, walk-sync@^1.1.3:
     ensure-posix-path "^1.1.0"
     matcher-collection "^1.1.1"
 
-walk-sync@^2.0.0, walk-sync@^2.0.2, walk-sync@^2.1.0:
+walk-sync@^2.0.0, walk-sync@^2.0.2, walk-sync@^2.1.0, walk-sync@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-2.2.0.tgz#80786b0657fcc8c0e1c0b1a042a09eae2966387a"
   integrity sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==


### PR DESCRIPTION
Adding a test scenario to test ember-fetch against embroider. 

The Embroider tests are failing due to duplicates babel plugins.

```
info Reasons this module exists
   - "ember-cli-typescript" depends on it
   - Hoisted from "ember-cli-typescript#@babel#plugin-proposal-optional-chaining"
   - Hoisted from "@embroider#webpack#@babel#plugin-proposal-optional-chaining"
   - Hoisted from "ember-cli-babel#@babel#preset-env#@babel#plugin-proposal-optional-chaining"
```

```
Duplicates detected are:
[
  {
    "alias": "/home/travis/build/ember-cli/ember-fetch/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js",
    "dirname": "/home/travis/build/ember-cli/ember-fetch",
    "ownPass": false,
    "file": {
      "request": "/home/travis/build/ember-cli/ember-fetch/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js",
      "resolved": "/home/travis/build/ember-cli/ember-fetch/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js"
    }
  },
  {
    "alias": "/home/travis/build/ember-cli/ember-fetch/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js",
    "dirname": "/home/travis/build/ember-cli/ember-fetch",
    "ownPass": false,
    "file": {
      "request": "/home/travis/build/ember-cli/ember-fetch/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js",
      "resolved": "/home/travis/build/ember-cli/ember-fetch/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js"
    }
  }
]
```

