### PR TITLE
Allow to use native promises instead of RSVP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
         - yarn lint:js
         - yarn test
         - PREFER_NATIVE=true yarn test
+        - NATIVE_PROMISE=true yarn test
         - npm run test:node
 
     - name: "Floating Dependencies"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ If all your [browser targets](https://guides.emberjs.com/release/configuring-emb
 
 The way you do import remains same.
 
+### Use native promise instead of RSVP
+
+If you do not want to use RSVP, but native Promises, you can specify this build config flag:
+
+```js
+// ember-cli-build.js
+let app = new EmberAddon(defaults, {
+  // Add options here
+  'ember-fetch': {
+    nativePromise: true
+  }
+});
+```
+
 ### Error Handling
 
 A `fetch` response is successful if `response.ok` is true,

--- a/assets/browser-fetch.js.t
+++ b/assets/browser-fetch.js.t
@@ -1,6 +1,5 @@
 (function (originalGlobal) {
   <%= moduleHeader %>
-    var Promise = RSVP.Promise;
     var supportProps = [
       'FormData',
       'FileReader',

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,6 +6,7 @@ module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
     'ember-fetch': {
+      nativePromise: process.env.NATIVE_PROMISE ? true : false,
       preferNative: process.env.PREFER_NATIVE ? true : false
     }
   });


### PR DESCRIPTION
I initially tried to get it to work with using `require('rsvp')` when building with Embroider.
However, I couldn't get it to run. I tried adding `rsvp` as a dedicated dependency, as well as `ember-auto-import`, and importing RSVP in an initializer, but nothing made it available under `require('rsvp')` in my embroider app.

I ended up adding an option that allows to opt out of using the RSVP wrapper at all. I think this is an acceptable and backwards compatible opt-out option that should be OK for apps that target only browsers that do not target IE11 anymore.

Let me know if you think this works, or if a different approach would work better.

Closes https://github.com/ember-cli/ember-fetch/issues/622
