### PR TITLE
feat(build): add `includePolyfill: never`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,16 @@ otherwise the polyfilled `fetch` will be installed during the first pass of the 
 
 If set to `false`, the polyfilled `fetch` will replace native `fetch` be there or not.
 
-If all your [browser targets](https://guides.emberjs.com/release/configuring-ember/build-targets/) support native `fetch`, and `preferNative: true`, the polyfill will not be included in the output build. If, for some reason, you still need the polyfill to be included in the bundle, you can set `alwaysIncludePolyfill: true`.
+If all your [browser targets](https://guides.emberjs.com/release/configuring-ember/build-targets/) support native `fetch`, and `preferNative: true`, the polyfill will not be included in the output build. If, for some reason, you still need the polyfill to be included in the bundle, you can set `includePolyfill: 'always'`.
 
 The way you do import remains same.
+
+If your browser targets do not support it natively, which would cause the
+polyfill to be included, but you still want to exclude it, e.g. because you are
+loading an external polyfill, e.g. via [polyfill.io](https://polyfill.io), you
+can set `includePolyfill: 'never'`. This also implies `preferNative: true`.
+
+The default behavior is `includePolyfill: 'if-necessary'`.
 
 ### Use native promise instead of RSVP
 

--- a/test/browsers-target-test.js
+++ b/test/browsers-target-test.js
@@ -4,22 +4,30 @@ const AddonFactory = require('../');
 const expect = require('chai').expect;
 const helpers = require('broccoli-test-helper');
 
+function makeAddonInstance({ browsers, ...config }) {
+  const addon = Object.create(AddonFactory);
+  Object.assign(addon, {
+    addons: [],
+    ui: {
+      writeWarnLine() {},
+      writeDeprecateLine() {},
+    }
+  });
+  addon._fetchBuildConfig = addon._normalizeBuildConfig(
+    { hasEmberSourceModules: true, browsers },
+    config
+  );
+  return addon;
+}
+
 describe(`Do not include the polyfill if the browser targets match`, function() {
   let output, subject, addon;
 
   beforeEach(function() {
-    addon = Object.create(AddonFactory);
-    Object.assign(addon, {
-      addons: [],
-      _fetchBuildConfig: {
-        preferNative: true,
-        alwaysIncludePolyfill: false,
-        browsers: ['last 1 chrome versions']
-      },
-      ui: {
-        writeWarnLine() {
-        }
-      }
+    addon = makeAddonInstance({
+      preferNative: true,
+      alwaysIncludePolyfill: false,
+      browsers: ['last 1 chrome versions']
     });
     subject = addon.treeForVendor();
     output = helpers.createBuilder(subject);
@@ -44,18 +52,10 @@ describe(`Ignore target browsers if preferNative is false`, function() {
   let output, subject, addon;
 
   beforeEach(function() {
-    addon = Object.create(AddonFactory);
-    Object.assign(addon, {
-      addons: [],
-      _fetchBuildConfig: {
-        preferNative: false,
-        alwaysIncludePolyfill: false,
-        browsers: ['last 1 chrome versions']
-      },
-      ui: {
-        writeWarnLine() {
-        }
-      }
+    addon = makeAddonInstance({
+      preferNative: false,
+      alwaysIncludePolyfill: false,
+      browsers: ['last 1 chrome versions']
     });
     subject = addon.treeForVendor();
     output = helpers.createBuilder(subject);
@@ -80,18 +80,10 @@ describe(`Include the polyfill if the browser targets do not match`, function() 
   let output, subject, addon;
 
   beforeEach(function() {
-    addon = Object.create(AddonFactory);
-    Object.assign(addon, {
-      addons: [],
-      _fetchBuildConfig: {
-        preferNative: true,
-        alwaysIncludePolyfill: false,
-        browsers: ['ie 11']
-      },
-      ui: {
-        writeWarnLine() {
-        }
-      }
+    addon = makeAddonInstance({
+      preferNative: true,
+      alwaysIncludePolyfill: false,
+      browsers: ['ie 11']
     });
     subject = addon.treeForVendor();
     output = helpers.createBuilder(subject);
@@ -112,22 +104,41 @@ describe(`Include the polyfill if the browser targets do not match`, function() 
 
 });
 
+describe(`Do not include the polyfill if the browser targets do not match, but includePolyfill='never'`, function () {
+  let output, subject, addon;
+
+  beforeEach(function() {
+    addon = makeAddonInstance({
+      includePolyfill: 'never',
+      browsers: ['ie 11']
+    });
+    subject = addon.treeForVendor();
+    output = helpers.createBuilder(subject);
+  });
+
+  afterEach(async function () {
+    await output.dispose();
+  });
+
+  it('fetch & AbortController polyfills are not included', async function () {
+    await output.build();
+    let files = output.read();
+    expect(files).to.have.all.keys('ember-fetch.js');
+    expect(files['ember-fetch.js']).to.include(`var preferNative = true`);
+    expect(files['ember-fetch.js']).to.not.include(`fetch.polyfill = true`);
+    expect(files['ember-fetch.js']).to.not.include(`class AbortController`);
+  });
+
+});
+
 describe(`Include the abortcontroller polyfill only if the browser targets support fetch only`, function() {
   let output, subject, addon;
 
   beforeEach(function() {
-    addon = Object.create(AddonFactory);
-    Object.assign(addon, {
-      addons: [],
-      _fetchBuildConfig: {
-        preferNative: true,
-        alwaysIncludePolyfill: false,
-        browsers: ['safari 11']
-      },
-      ui: {
-        writeWarnLine() {
-        }
-      }
+    addon = makeAddonInstance({
+      preferNative: true,
+      alwaysIncludePolyfill: false,
+      browsers: ['safari 11']
     });
     subject = addon.treeForVendor();
     output = helpers.createBuilder(subject);
@@ -148,22 +159,41 @@ describe(`Include the abortcontroller polyfill only if the browser targets suppo
 
 });
 
-describe(`Include the polyfill if alwaysIncludePolyfill=true`, function() {
+describe(`Include the polyfill if includePolyfill='always'`, function() {
   let output, subject, addon;
 
   beforeEach(function() {
-    addon = Object.create(AddonFactory);
-    Object.assign(addon, {
-      addons: [],
-      _fetchBuildConfig: {
-        preferNative: true,
-        alwaysIncludePolyfill: true,
-        browsers: ['last 1 chrome versions']
-      },
-      ui: {
-        writeWarnLine() {
-        }
-      }
+    addon = makeAddonInstance({
+      includePolyfill: 'always',
+      browsers: ['last 1 chrome versions']
+    });
+    subject = addon.treeForVendor();
+    output = helpers.createBuilder(subject);
+  });
+
+  afterEach(async function () {
+    await output.dispose();
+  });
+
+  it('fetch & AbortController polyfills are included', async function () {
+    await output.build();
+    let files = output.read();
+    expect(files).to.have.all.keys('ember-fetch.js');
+    expect(files['ember-fetch.js']).to.include(`var preferNative = false`);
+    expect(files['ember-fetch.js']).to.include(`fetch.polyfill = true`);
+    expect(files['ember-fetch.js']).to.include(`class AbortController`);
+  });
+
+});
+
+describe(`[deprecated] Include the polyfill if alwaysIncludePolyfill=true`, function() {
+  let output, subject, addon;
+
+  beforeEach(function() {
+    addon = makeAddonInstance({
+      preferNative: true,
+      alwaysIncludePolyfill: true,
+      browsers: ['last 1 chrome versions']
     });
     subject = addon.treeForVendor();
     output = helpers.createBuilder(subject);
@@ -183,3 +213,4 @@ describe(`Include the polyfill if alwaysIncludePolyfill=true`, function() {
   });
 
 });
+


### PR DESCRIPTION
This PR allows users to explicitly exclude the polyfill, even if the browser targets require it. This allows users to load the polyfill on their own terms, e.g. via services like [https://polyfill.io](polyfill.io).

- Add `includePolyfill` config flag with values:
	- `'always'`: Always include the polyfill, even if all browser targets support `fetch` natively and `preferNative` is enabled. This is equivalent to the current `alwaysIncludePolyfill: true`.
	- `'if-necessary'`: Include the polyfill, if the browser targets do not support `fetch` natively. Implies `preferNative: true`.
	- `'never'`: Never include the polyfill, regardless of browser targets. Implies `preferNative: false`.
	- `undefined` (default):
	  1. If `alwaysIncludePolyfill === true` → `'always'`
	  2. Depending on `preferNative`, ...
	     - if `true` → `'if-necessary'`
	     - if `false` → `'always'`
- Deprecate `alwaysIncludePolyfill`.