### PR TITLE
add node_modules to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@
 
 # dependencies
 /bower_components/
+/node_modules/
 
 # misc
 /coverage/


### PR DESCRIPTION
How was this not there before? 🤔 