### PR TITLE
Avoid `ember-polyfills.deprecate-assign` deprecation

### DIFF
--- a/addon/utils/mung-options-for-fetch.ts
+++ b/addon/utils/mung-options-for-fetch.ts
@@ -1,4 +1,4 @@
-import { assign } from '@ember/polyfills';
+import { assign as emberAssign } from '@ember/polyfills';
 import { serializeQueryParams } from './serialize-query-params';
 import {
   Method,
@@ -6,6 +6,9 @@ import {
   AjaxOptions,
   isPlainObject
 } from 'ember-fetch/types';
+
+// Avoid `ember-polyfills.deprecate-assign` deprecation.
+const assign = Object.assign || emberAssign;
 
 /**
  * Helper function that translates the options passed to `jQuery.ajax` into a format that `fetch` expects.


### PR DESCRIPTION
Not sure if this is the best approach, but `ember-fetch` still supports IE11 according to the docs:
https://github.com/ember-cli/ember-fetch#browser-support

Closes #693.
Closes #707.