### PR TITLE
Rename import path to 'ember-fetch'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,6 @@ Available imports:
 import fetch, { Headers, Request, Response, AbortController } from 'ember-fetch';
 ```
 
-### Use with TypeScript
-To use `ember-fetch` with TypeScript or enable editor's type support, You can add `"fetch": ["node_modules/ember-fetch"]` to your `tsconfig.json`.
-
-```json
-{
-  "compilerOptions": {
-    "paths": {
-      "fetch": [
-        "node_modules/ember-fetch"
-      ]
-    }
-  }
-}
-```
-
 ### Use with Ember Data
 
 ember-data@3.9.2 was released with built-in fetch support, if your ember-data is below 3.9.2, please checkout [ember-fetch v7.x](https://github.com/ember-cli/ember-fetch/tree/v7.x).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ember-fetch requries ember-cli 2.13 or above.
 
 ```js
 import Route from '@ember/routing/route';
-import fetch from 'fetch';
+import fetch from 'ember-fetch';
 
 export default Route.extend({
   model() {
@@ -34,7 +34,7 @@ export default Route.extend({
 
 Available imports:
 ```js
-import fetch, { Headers, Request, Response, AbortController } from 'fetch';
+import fetch, { Headers, Request, Response, AbortController } from 'ember-fetch';
 ```
 
 ### Use with TypeScript
@@ -126,7 +126,7 @@ otherwise you can read the status code to determine the bad response type.
 
 ```js
 import Route from '@ember/routing/route';
-import fetch from 'fetch';
+import fetch from 'ember-fetch';
 import {
   isAbortError,
   isServerErrorResponse,

--- a/fastboot/instance-initializers/setup-fetch.js
+++ b/fastboot/instance-initializers/setup-fetch.js
@@ -1,4 +1,4 @@
-import { setupFastboot } from 'fetch';
+import { setupFastboot } from 'ember-fetch';
 
 /**
  * To allow relative URLs for Fastboot mode, we need the per request information

--- a/index.js
+++ b/index.js
@@ -238,14 +238,14 @@ module.exports = {
   _getModuleHeader({ hasEmberSourceModules, nativePromise }) {
     if (hasEmberSourceModules && nativePromise) {
       return `
-define('fetch', ['exports', 'ember'], function(exports, Ember__module) {
+define('ember-fetch', ['exports', 'ember'], function(exports, Ember__module) {
   'use strict';
   var Ember = 'default' in Ember__module ? Ember__module['default'] : Ember__module;`;
     }
 
     if (hasEmberSourceModules) {
       return `
-define('fetch', ['exports', 'ember', 'rsvp'], function(exports, Ember__module, RSVP__module) {
+define('ember-fetch', ['exports', 'ember', 'rsvp'], function(exports, Ember__module, RSVP__module) {
   'use strict';
   var Ember = 'default' in Ember__module ? Ember__module['default'] : Ember__module;
   var RSVP = 'default' in RSVP__module ? RSVP__module['default'] : RSVP__module;
@@ -254,13 +254,13 @@ define('fetch', ['exports', 'ember', 'rsvp'], function(exports, Ember__module, R
 
     if (nativePromise) {
       return `
-define('fetch', ['exports'], function(exports) {
+define('ember-fetch', ['exports'], function(exports) {
   'use strict';
   var Ember = originalGlobal.Ember;`;
     }
 
     return `
-define('fetch', ['exports'], function(exports) {
+define('ember-fetch', ['exports'], function(exports) {
   'use strict';
   var Ember = originalGlobal.Ember;
   var Promise = Ember.RSVP.Promise;`;

--- a/test/fixtures/dummy/app/routes/index.js
+++ b/test/fixtures/dummy/app/routes/index.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
-import fetch, { Request } from 'fetch';
+import fetch, { Request } from 'ember-fetch';
 import ajax from 'ember-fetch/ajax';
 
 export default Route.extend({

--- a/tests/acceptance/error-test.js
+++ b/tests/acceptance/error-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import Pretender from 'pretender';
-import fetch, { AbortController } from 'fetch';
+import fetch, { AbortController } from 'ember-fetch';
 import {
   isUnauthorizedResponse,
   isForbiddenResponse,

--- a/tests/acceptance/root-test.js
+++ b/tests/acceptance/root-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { visit, click, find, currentRouteName } from '@ember/test-helpers';
 import Pretender from 'pretender';
-import fetch from 'fetch';
+import fetch from 'ember-fetch';
 
 var server;
 

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { run } from '@ember/runloop';
-import fetch from 'fetch';
+import fetch from 'ember-fetch';
 
 export default Controller.extend({
   actions: {

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
-import fetch from 'fetch';
+import fetch from 'ember-fetch';
 
 export default Route.extend({
   model: function() {

--- a/tests/unit/abortcontroller-test.js
+++ b/tests/unit/abortcontroller-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { AbortController } from 'fetch';
+import { AbortController } from 'ember-fetch';
 
 module('AbortController', function() {
   test('signal', function(assert) {

--- a/tests/unit/error-test.js
+++ b/tests/unit/error-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { Response } from 'fetch';
+import { Response } from 'ember-fetch';
 
 import {
   isUnauthorizedResponse,

--- a/tests/unit/headers-test.js
+++ b/tests/unit/headers-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { Headers } from 'fetch';
+import { Headers } from 'ember-fetch';
 
 module('Headers', function() {
   test('iterator', function(assert) {

--- a/tests/unit/utils/determine-body-promise-test.js
+++ b/tests/unit/utils/determine-body-promise-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { Response } from 'fetch';
+import { Response } from 'ember-fetch';
 import determineBodyPromise from 'ember-fetch/utils/determine-body-promise';
 
 module('Unit | determineBodyPromise', function() {


### PR DESCRIPTION
As per this issue: https://github.com/ember-cli/ember-fetch/issues/330 `ember-fetch` is incompatible with v2 addons and still required for some Ember projects. 

This fixes the issue with v2 addons and follows more direct naming conventions. 
I also removed the TS portion from the README as that workaround is no longer needed now that the module name matches the import name. 