### PR TITLE
drop support for node < 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["12"]
+        node-version:
+          - 16
+          - 18
+          - 20
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test
 
@@ -41,12 +46,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["12"]
+        node-version:
+          - 16
+          - 18
+          - 20
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - run: yarn install --frozen-lockfile --non-interactive
       - run: PREFER_NATIVE=true yarn test
 
@@ -56,12 +66,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["12"]
+        node-version:
+          - 16
+          - 18
+          - 20
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - run: yarn install --frozen-lockfile --non-interactive
       - run: NATIVE_PROMISE=true yarn test
 
@@ -71,12 +86,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["12"]
+        node-version:
+          - 16
+          - 18
+          - 20
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn run test:node
 
@@ -105,8 +125,9 @@ jobs:
             allow-failure: true
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 16
       - name: install dependencies
         run: yarn install
       - name: test

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "typescript": "^4.1.3"
   },
   "engines": {
-    "node": ">= 10"
+    "node": "16.x || 18.x || >=20.x "
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
@@ -102,7 +102,7 @@
     ]
   },
   "volta": {
-    "node": "10.24.1",
+    "node": "16.20.2",
     "yarn": "1.22.10"
   }
 }


### PR DESCRIPTION
We're starting to hit issues with Node 14 in PRs like https://github.com/ember-cli/ember-fetch/pull/741 with Node 14 so we need to update our support.

I know node 16 is already EOL but I thought it would be best to keep it for the next major 👍 

Also I noticed that the CI file wasn't using setup-node correctly 🤦 